### PR TITLE
Better support for virtual interfaces

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -2,5 +2,8 @@
   "presets": [
     "@babel/preset-env",
     "@babel/preset-react"
+  ],
+  "plugins": [
+    "@babel/plugin-transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",
+    "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/preset-env": "^7.5.4",
     "@babel/preset-react": "^7.0.0",
     "@testing-library/jest-dom": "^5.11.4",

--- a/src/components/BridgeForm.js
+++ b/src/components/BridgeForm.js
@@ -30,7 +30,7 @@ import {
     TextInput
 } from '@patternfly/react-core';
 import cockpit from 'cockpit';
-import { useNetworkDispatch, useNetworkState, actionTypes } from '../NetworkContext';
+import { useNetworkDispatch, useNetworkState, addConnection, updateConnection } from '../NetworkContext';
 import interfaceType from '../lib/model/interfaceType';
 
 const _ = cockpit.gettext;
@@ -51,27 +51,16 @@ const BridgeForm = ({ isOpen, onClose, bridge }) => {
         }
     }, [bridge, isEditing, interfaces]);
 
-    const addConnection = () => {
-        dispatch({
-            type: actionTypes.ADD_CONNECTION,
-            payload: { name, ports: selectedPorts, type: interfaceType.BRIDGE }
-        });
-    };
-
-    const updateConnection = () => {
-        dispatch({
-            type: actionTypes.UPDATE_CONNECTION,
-            payload: { id: bridge.id, changes: { name, ports: selectedPorts } }
-        });
-    };
-
     const addOrUpdateConnection = () => {
+        let promise = null;
+
         if (isEditing) {
-            updateConnection();
+            promise = updateConnection(dispatch, bridge, { name, ports: selectedPorts });
         } else {
-            addConnection();
+            promise = addConnection(dispatch, { name, ports: selectedPorts, type: interfaceType.BRIDGE });
         }
-        onClose();
+
+        promise.then(onClose).catch(console.error);
     };
 
     const handleSelectedPorts = (name) => (value) => {

--- a/src/lib/NetworkClient.js
+++ b/src/lib/NetworkClient.js
@@ -38,8 +38,8 @@ class NetworkClient {
      *
      * @returns {Promise<Array|Error>} Resolves to an array of objects in case of success
      */
-    getConnections() {
-        return this.adapter.connections();
+    async getConnections() {
+        return await this.adapter.connections();
     }
 
     /**
@@ -47,8 +47,9 @@ class NetworkClient {
      *
      * @returns {Promise<Array|Error>} Resolves to an array of objects in case of success
      */
-    getInterfaces() {
-        return this.adapter.interfaces();
+    async getInterfaces() {
+        const ifaces = await this.adapter.interfaces();
+        return ifaces.filter(i => i.name !== 'lo');
     }
 
     /**

--- a/src/lib/NetworkClient.test.js
+++ b/src/lib/NetworkClient.test.js
@@ -30,8 +30,6 @@ describe("NetworkClient", () => {
             return client.getConnections().then(data => {
                 const conn = data[0];
                 expect(conn).toEqual(
-                    // TODO: filter out the loopback interface
-                    expect.objectContaining({ name: "lo" }),
                     expect.objectContaining({ name: "eth0" })
                 );
             });
@@ -42,7 +40,7 @@ describe("NetworkClient", () => {
         it("returns the list of interfaces", () => {
             expect.assertions(2);
             return client.getInterfaces().then(data => {
-                expect(data).toHaveLength(5);
+                expect(data).toHaveLength(4);
 
                 const eth0 = data.find(i => i.name == 'eth0');
                 expect(eth0).toEqual(

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -49,7 +49,7 @@ class WickedAdapter {
         if (this._connections) return this._connections;
 
         const conns = await this.client.getConfigurations();
-        this._connections = conns.map(createConnection);
+        this._connections = conns.map(createConnection).filter(c => c.name !== 'lo');
         return this._connections;
     }
 
@@ -62,7 +62,7 @@ class WickedAdapter {
         if (this._interfaces) return this._interfaces;
 
         const ifaces = await this.client.getInterfaces();
-        this._interfaces = ifaces.map(createInterface);
+        this._interfaces = ifaces.map(createInterface).filter(i => i.name !== 'lo');
 
         const conns = await this.connections();
         const names = this._interfaces.map(i => i.name);

--- a/src/lib/wicked/adapter.test.js
+++ b/src/lib/wicked/adapter.test.js
@@ -66,7 +66,8 @@ describe('#connections', () => {
 
         return adapter.interfaces().then(interfaces => {
             expect(interfaces).toEqual([
-                expect.objectContaining({ name: 'eth0', type: 'eth' }),
+                expect.objectContaining({ name: 'eth0', type: 'eth', virtual: false }),
+                expect.objectContaining({ name: 'br0', type: 'br', virtual: true }),
             ]);
         });
     });

--- a/src/lib/wicked/client.js
+++ b/src/lib/wicked/client.js
@@ -99,15 +99,9 @@ class WickedClient {
      *
      * @return {Promise.<Array.<Object>>} Promise that resolves to a list of interfaces
      */
-    getInterfaces() {
-        return new Promise((resolve, reject) => {
-            cockpit.spawn(['/usr/sbin/wicked', 'show-xml'])
-                    .then(stdout => {
-                        const result = XmlToJson(stdout, ['body']);
-                        resolve(result);
-                    })
-                    .catch(console.error);
-        });
+    async getInterfaces() {
+        const stdout = await cockpit.spawn(['/usr/sbin/wicked', 'show-xml']);
+        return XmlToJson(stdout, ['body']);
     }
 
     /**
@@ -115,15 +109,9 @@ class WickedClient {
      *
      * @return {Promise.<Array.<Object>>} Promise that resolves to a list of interfaces
      */
-    getConfigurations() {
-        return new Promise((resolve, reject) => {
-            cockpit.spawn(['/usr/sbin/wicked', 'show-config'])
-                    .then(stdout => {
-                        const result = XmlToJson(stdout, ['body', 'slaves', 'addresses']);
-                        resolve(result);
-                    })
-                    .catch(console.error);
-        });
+    async getConfigurations() {
+        const stdout = await cockpit.spawn(['/usr/sbin/wicked', 'show-config']);
+        return XmlToJson(stdout, ['body', 'slaves', 'addresses']);
     }
 
     /**


### PR DESCRIPTION
* Do not show the 'loopback' interface.
* Detect those virtual interfaces that are inactive.
* Use the new addConnection and updateConnection helpers in bridge and bonding forms.