### PR TITLE
Write bridge/bonding settings to the sysconfig files

### DIFF
--- a/src/components/BondDetails.js
+++ b/src/components/BondDetails.js
@@ -25,13 +25,13 @@ import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
 
-const BondDetails = ({ bond }) => {
+const BondDetails = ({ connection }) => {
     const [isFormOpen, setFormOpen] = useState(false);
 
     return (
         <>
             <a href="#" onClick={() => setFormOpen(true)}>{_("Configure")}</a>
-            { isFormOpen && <BondForm isOpen={isFormOpen} bond={bond} onClose={() => setFormOpen(false)} /> }
+            { isFormOpen && <BondForm isOpen={isFormOpen} connection={connection} onClose={() => setFormOpen(false)} /> }
         </>
     );
 };

--- a/src/components/BondForm.js
+++ b/src/components/BondForm.js
@@ -42,34 +42,6 @@ const modeOptions = bondingModes.values.map(mode => {
     return { value: mode, label: bondingModes.label(mode) };
 });
 
-/**
- * Returns given options string as an object
- *
- * @param {string} options - options in a key=value format, separated by space
- * @return {object} an object holding given options
- */
-const parseOptions = (options) => {
-    return options.split(" ").reduce((obj, option) => {
-        if (option) {
-            const [key, value] = option.split("=");
-            obj[key] = value;
-        }
-
-        return obj;
-    }, {});
-};
-
-/**
- * Returns given options object serialized as a key=value string
- *
- * @param {object} options - options object
- * @return {string} a key=value string
- */
-const serializeOptions = (options) => (
-    Object.keys(options).map((key) => `${key}=${options[key]}`)
-            .join(" ")
-);
-
 const BondForm = ({ isOpen, onClose, connection }) => {
     const { bond } = connection || {};
     const isEditing = !!connection;
@@ -90,13 +62,12 @@ const BondForm = ({ isOpen, onClose, connection }) => {
     }, [connection, isEditing, interfaces]);
 
     const addOrUpdateConnection = () => {
-        const { mode, ...rest } = parseOptions(options);
         const bondingAttrs = {
             name,
             bond: {
-                mode: parseInt(mode) || bondingMode, // TODO: re-evaluate if we actually want this
+                mode,
                 interfaces: selectedInterfaces,
-                options: serializeOptions(rest)
+                options
             }
         };
         let promise = null;

--- a/src/components/BridgeDetails.js
+++ b/src/components/BridgeDetails.js
@@ -25,13 +25,13 @@ import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
 
-const BridgeDetails = ({ bridge }) => {
+const BridgeDetails = ({ connection }) => {
     const [isFormOpen, setFormOpen] = useState(false);
 
     return (
         <>
             <a href="#" onClick={() => setFormOpen(true)}>{_("Configure")}</a>
-            { isFormOpen && <BridgeForm isOpen={isFormOpen} bridge={bridge} onClose={() => setFormOpen(false)} /> }
+            { isFormOpen && <BridgeForm isOpen={isFormOpen} connection={connection} onClose={() => setFormOpen(false)} /> }
         </>
     );
 };

--- a/src/components/BridgeForm.js
+++ b/src/components/BridgeForm.js
@@ -35,9 +35,10 @@ import interfaceType from '../lib/model/interfaceType';
 
 const _ = cockpit.gettext;
 
-const BridgeForm = ({ isOpen, onClose, bridge }) => {
-    const isEditing = !!bridge;
-    const [name, setName] = useState(bridge?.name || "");
+const BridgeForm = ({ isOpen, onClose, connection }) => {
+    const { bridge } = connection || {};
+    const isEditing = !!connection;
+    const [name, setName] = useState(connection?.name || "");
     const [selectedPorts, setSelectedPorts] = useState(bridge?.ports || []);
     const [candidatePorts, setCandidatePorts] = useState([]);
     const { interfaces } = useNetworkState();
@@ -45,19 +46,23 @@ const BridgeForm = ({ isOpen, onClose, bridge }) => {
 
     useEffect(() => {
         if (isEditing) {
-            setCandidatePorts(Object.values(interfaces).filter(i => i.id !== bridge.id));
+            setCandidatePorts(Object.values(interfaces).filter(i => i.id !== connection.id));
         } else {
             setCandidatePorts(Object.values(interfaces));
         }
-    }, [bridge, isEditing, interfaces]);
+    }, [connection, isEditing, interfaces]);
 
     const addOrUpdateConnection = () => {
         let promise = null;
 
         if (isEditing) {
-            promise = updateConnection(dispatch, bridge, { name, ports: selectedPorts });
+            promise = updateConnection(
+                dispatch, connection, { name, bridge: { ports: selectedPorts } }
+            );
         } else {
-            promise = addConnection(dispatch, { name, ports: selectedPorts, type: interfaceType.BRIDGE });
+            promise = addConnection(
+                dispatch, { name, type: interfaceType.BRIDGE, bridge: { ports: selectedPorts, } }
+            );
         }
 
         promise.then(onClose).catch(console.error);

--- a/src/components/InterfaceDetails.js
+++ b/src/components/InterfaceDetails.js
@@ -47,20 +47,20 @@ const macAddress = (iface) => {
     );
 };
 
-const bondDetails = (bond) => {
+const bondDetails = (connection) => {
     return (
         <>
             <dt>{_("Bond")}</dt>
-            <dd><BondDetails bond={bond} /></dd>
+            <dd><BondDetails connection={connection} /></dd>
         </>
     );
 };
 
-const bridgeDetails = (bridge) => {
+const bridgeDetails = (connection) => {
     return (
         <>
             <dt>{_("Bridge")}</dt>
-            <dd><BridgeDetails bridge={bridge} /></dd>
+            <dd><BridgeDetails connection={connection} /></dd>
         </>
     );
 };

--- a/src/lib/model/bondingMode.js
+++ b/src/lib/model/bondingMode.js
@@ -24,13 +24,13 @@ import cockpit from 'cockpit';
 const _ = cockpit.gettext;
 const NC_ = cockpit.noop;
 
-const BALANCE_RR = 0;
-const ACTIVE_BACKUP = 1;
-const BALANCE_XOR = 2;
-const BROADCAST = 3;
-const DLA_802_3AD = 4;
-const BALANCE_TLB = 5;
-const BALANCE_ALB = 6;
+const BALANCE_RR = 'balance-rr';
+const ACTIVE_BACKUP = 'active-backup';
+const BALANCE_XOR = 'balance-xor';
+const BROADCAST = 'broadcast'
+const DLA_802_3AD = '802.3ad'
+const BALANCE_TLB = 'balance-tlb';
+const BALANCE_ALB = 'balance-alb';
 
 const values = [
     BALANCE_RR,
@@ -45,11 +45,12 @@ const values = [
 const labels = {
     [BALANCE_RR]: NC_("Round Robin"),
     [ACTIVE_BACKUP]: NC_("Active Backup"),
-    [BALANCE_XOR]: NC_("XOR"),
+    [BALANCE_XOR]: NC_("Balance XOR"),
     [BROADCAST]: NC_("Broadcast"),
     [DLA_802_3AD]: NC_("802.3ad Dynamic Link Aggregation"),
     [BALANCE_TLB]: NC_("Adaptive Transmit Load Balancing"),
     [BALANCE_ALB]: NC_("Adaptive Load Balancing")
+
 };
 
 const label = (mode) => _(labels[mode]);

--- a/src/lib/model/bondingMode.js
+++ b/src/lib/model/bondingMode.js
@@ -27,8 +27,8 @@ const NC_ = cockpit.noop;
 const BALANCE_RR = 'balance-rr';
 const ACTIVE_BACKUP = 'active-backup';
 const BALANCE_XOR = 'balance-xor';
-const BROADCAST = 'broadcast'
-const DLA_802_3AD = '802.3ad'
+const BROADCAST = 'broadcast';
+const DLA_802_3AD = '802.3ad';
 const BALANCE_TLB = 'balance-tlb';
 const BALANCE_ALB = 'balance-alb';
 

--- a/src/lib/model/index.js
+++ b/src/lib/model/index.js
@@ -142,15 +142,20 @@ const propsByType = (type, props) => {
  * @ignore
  */
 const propsByConnectionType = {
-    [interfaceType.BONDING]: ({ bondingMode = bondingModeEnum.ACTIVE_BACKUP, options = "" }) => {
+    [interfaceType.BONDING]: ({ bond = {} } = {}) => {
+        const { mode = bondingModeEnum.ACTIVE_BACKUP, options = "", interfaces = [] } = bond;
         return {
-            bondingMode,
-            options
+            bond: {
+                mode,
+                options,
+                interfaces
+            }
         };
     },
-    [interfaceType.BRIDGE]: ({ ports = [] }) => {
+    [interfaceType.BRIDGE]: ({ bridge = {} } = {}) => {
+        const { ports = [] } = bridge;
         return {
-            ports
+            bridge: { ports }
         };
     }
 };

--- a/src/lib/model/index.test.js
+++ b/src/lib/model/index.test.js
@@ -20,11 +20,47 @@
  */
 
 import { createConnection, mergeConnection } from './index';
+import bondingMode from './bondingMode';
+import interfaceType from './interfaceType';
 
 describe('#createConnection', () => {
     it('creates an ethernet type connection', () => {
         const conn = createConnection({ name: 'eth0' });
         expect(conn).toEqual(expect.objectContaining({ name: 'eth0', type: 'eth' }));
+    });
+
+    describe('when it is a bridge device', () => {
+        it('sets the default bride configuration', () => {
+            const conn = createConnection({ name: 'br0', type: interfaceType.BRIDGE });
+            expect(conn.bridge).toEqual({ ports: [] });
+        });
+
+        it('sets the bridge configuration to the given values', () => {
+            const conn = createConnection({
+                name: 'br0', type: interfaceType.BRIDGE, bridge: { ports: ['eth0'] }
+            });
+            expect(conn.bridge).toEqual({ ports: ['eth0'] });
+        });
+    });
+
+    describe('when it is a bond device', () => {
+        it('sets the default bonding configuration', () => {
+            const conn = createConnection({ name: 'bond0', type: interfaceType.BONDING });
+            expect(conn.bond).toEqual({
+                interfaces: [], mode: bondingMode.ACTIVE_BACKUP, options: ""
+            });
+        });
+
+        it('sets the bonding configuration to the given values', () => {
+            const conn = createConnection({
+                name: 'bond0', type: interfaceType.BONDING,
+                bond: { interfaces: ['eth0'], mode: bondingMode.BALANCE_RR, options: "some-option" }
+            });
+
+            expect(conn.bond).toEqual({
+                interfaces: ['eth0'], mode: bondingMode.BALANCE_RR, options: "some-option"
+            });
+        });
     });
 });
 

--- a/src/lib/wicked/client.js
+++ b/src/lib/wicked/client.js
@@ -111,7 +111,7 @@ class WickedClient {
      */
     async getConfigurations() {
         const stdout = await cockpit.spawn(['/usr/sbin/wicked', 'show-config']);
-        return XmlToJson(stdout, ['body', 'slaves', 'addresses']);
+        return XmlToJson(stdout, ['body', 'slaves', 'addresses', 'ports']);
     }
 
     /**

--- a/src/lib/wicked/connections.test.js
+++ b/src/lib/wicked/connections.test.js
@@ -24,6 +24,7 @@ import interfaceType from '../model/interfaceType';
 import startMode from '../model/startMode';
 import bootProtocol from '../model/bootProtocol';
 import addressType from '../model/addressType';
+import bondingMode from '../model/bondingMode';
 
 describe('#createConnection', () => {
     const wickedConfig = {
@@ -66,5 +67,44 @@ describe('#createConnection', () => {
     it('do not set a boot protocol', () => {
         const connection = createConnection(wickedConfig);
         expect(connection.bootProto).toBeUndefined();
+    });
+
+    describe('when it is a brige device', () => {
+        const wickedConfig = {
+            name: 'br0',
+            bridge: {
+                stp: true,
+                ports: ['eth0', 'eth1']
+            }
+
+        };
+
+        it('sets the bridge specific properties', () => {
+            const connection = createConnection(wickedConfig);
+            expect(connection.bridge).toEqual({
+                ports: ['eth0', 'eth1']
+            });
+        });
+    });
+
+    describe('when it is a bond device', () => {
+        const wickedConfig = {
+            name: 'bond0',
+            bond: {
+                mode: 'balance-rr',
+                miimon: { frequency: "100", "carrier-detect": "netif" },
+                slaves: ['eth0', 'eth1'],
+                options: 'some-option'
+            },
+        };
+
+        it('sets the bonding specific properties', () => {
+            const conn = createConnection(wickedConfig);
+            expect(conn.bond).toEqual({
+                mode: bondingMode.BALANCE_RR,
+                interfaces: ['eth0', 'eth1'],
+                options: 'some-option'
+            });
+        });
     });
 });


### PR DESCRIPTION
This PR implements the writing of bridge/bond devices to the `sysconfig` files. Additionally, it extends the test suite and simplify a bit the BondForm.