### PR TITLE
IP configuration improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 /.vagrant
 package-lock.json
 Test*FAIL*
+doc/
 bots/
 test/common/
 test/images/

--- a/src/components/AddressesDataList.js
+++ b/src/components/AddressesDataList.js
@@ -49,7 +49,16 @@ const FIELDS = {
     label: { component: TextInput, props: { placeholder: _("Label"), "aria-label": _("Label") } }
 };
 
-const AddressesDataList = ({ addresses, updateAddresses }) => {
+/**
+ * Component for managing a collection of {@link module/model~AddressConfig}
+ *
+ * @param {Object} props - component props
+ * @param {Array<{module/modell~AddressConfig}>} addresses - the addresses collection
+ * @param {function} updateAddresses - callback function to be called when adding or removing
+ *    addresses
+ * @param {boolean} [allowEmpty=true] - whether the component should allow to delete all items
+ */
+const AddressesDataList = ({ addresses, updateAddresses, allowEmpty = true }) => {
     const addAddress = () => {
         const address = createAddressConfig();
         const currentAddresses = [...addresses];
@@ -93,15 +102,23 @@ const AddressesDataList = ({ addresses, updateAddresses }) => {
             );
         });
 
+        const renderDeleteAction = () => {
+            if (!allowEmpty && addresses.length === 1) return null;
+
+            return (
+                <DataListAction>
+                    <Button variant="secondory" className="btn-sm" onClick={() => deleteAddress(id)}>
+                        <MinusIcon />
+                    </Button>
+                </DataListAction>
+            );
+        };
+
         return (
             <DataListItem key={`address-${id}`}>
                 <DataListItemRow>
                     <DataListItemCells dataListCells={cells} />
-                    <DataListAction>
-                        <Button variant="secondory" className="btn-sm" onClick={() => deleteAddress(id)}>
-                            <MinusIcon />
-                        </Button>
-                    </DataListAction>
+                    { renderDeleteAction() }
                 </DataListItemRow>
             </DataListItem>
         );

--- a/src/components/BootProtoSelector.js
+++ b/src/components/BootProtoSelector.js
@@ -24,7 +24,15 @@ import bootProtocol from '../lib/model/bootProtocol';
 
 import { FormSelect, FormSelectOption } from '@patternfly/react-core';
 
-const bootProtocolOptions = bootProtocol.values.map(bootProto => {
+// FIXME: These are the boot protocols supported by wicked. Improve the selector to choose them
+// dynamically according to the network backend in use.
+const supportedBootProtocols = [
+    bootProtocol.NONE,
+    bootProtocol.STATIC,
+    bootProtocol.DHCP
+];
+
+const bootProtocolOptions = supportedBootProtocols.map(bootProto => {
     return { value: bootProto, label: bootProtocol.label(bootProto) };
 });
 

--- a/src/components/BootProtoSelector.js
+++ b/src/components/BootProtoSelector.js
@@ -32,7 +32,7 @@ const BootProtoSelector = ({ value, onChange }) => {
     return (
         <FormSelect value={value} onChange={onChange} id="bootProto">
             {bootProtocolOptions.map((option, index) => (
-                <FormSelectOption key={index} value={option.value} label={option.label} />
+                <FormSelectOption key={option.value} value={option.value} label={option.label} />
             ))}
         </FormSelect>
     );

--- a/src/components/IPSettingsForm.js
+++ b/src/components/IPSettingsForm.js
@@ -19,9 +19,11 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useState } from 'react';
-import { isValidIP } from '../lib/utils';
+import React, { useState, useEffect } from 'react';
 import cockpit from 'cockpit';
+import { isValidIP } from '../lib/utils';
+import bootProtocol from '../lib/model/bootProtocol';
+import { createAddressConfig } from '../lib/model';
 
 import {
     Alert,
@@ -36,21 +38,41 @@ import { useNetworkDispatch, updateConnection } from '../NetworkContext';
 import BootProtoSelector from "./BootProtoSelector";
 import AddressesDataList from "./AddressesDataList";
 
-const _ = cockpit.gettext;
+const { gettext: _, format } = cockpit;
 
+/**
+ * Cleans up given collection of addresses
+ *
+ * Basically, removing duplicated entries and those without IP
+ *
+ * @param {Array<module:model~AddressConfig>} addresses - addresses collection to sanitize
+ * @return {Array<module:model~AddressConfig>}
+ */
 const sanitize = (addresses) => {
-    return addresses.filter((addr, index, collection) => {
-    // Reject addresses without IP
+    return addresses.filter((addr, idx, collection) => {
+        // Reject addresses without IP
         if (addr.local === undefined || addr.local.trim() === "") return false;
 
         // If duplicated (same address, same label), keep only one
-        const idx = collection.findIndex((item) => item.local === addr.local && item.label === addr.label);
-        return idx === index;
+        const firstIdx = collection.findIndex((item) => item.local === addr.local && item.label === addr.label);
+        return idx === firstIdx;
     });
 };
 
+/**
+ * Checks if there is an invalid IP in given addresses collection
+ *
+ * @param {Array<module:model~AddressConfig>} addresses - addresses collection to check
+ * @return {boolean} true if an invalid IP is found; false otherwise
+ */
 const findInvalidIP = addresses => addresses.find((addr) => !isValidIP(addr.local));
 
+/**
+ * Checks if there is a repeated label in given addresses collection
+ *
+ * @param {Array<module:model~AddressConfig>} addresses - addresses collection to check
+ * @return {boolean} true if a label is used more than once; false otherwise
+ */
 const findRepeatedLabel = (addresses) => {
     return addresses.find((addr, idx, collection) => {
         const firstIdx = collection.findIndex((item) => item.label === addr.label);
@@ -58,37 +80,101 @@ const findRepeatedLabel = (addresses) => {
     });
 };
 
-const IPSettingsForm = ({ ipVersion = 'ipv4', connection, isOpen, onClose }) => {
+/**
+ * Form to configure the IP settings
+ *
+ * @param {Object} props - form props
+ * @param {object} props.connection - the connection object
+ * @param {string} [props.ipVersion=ipv4] - the IP version
+ * @param {boolean} [props.isOpen=false] - whether the form is displayed or not
+ * @param {function} [props.onClose] - callback function to be called when the form is closed
+ */
+const IPSettingsForm = ({ connection, ipVersion = 'ipv4', isOpen, onClose }) => {
     const dispatch = useNetworkDispatch();
     const settings = connection[ipVersion];
     const [bootProto, setBootProto] = useState(settings.bootProto);
     const [addresses, setAddresses] = useState(settings.addresses);
+    const [addressRequired, setAddressRequired] = useState(settings.bootProto === bootProtocol.STATIC);
     const [errorMessages, setErrorMessages] = useState([]);
     const [isApplying, setIsApplying] = useState(false);
 
-    const handleSubmit = () => {
-        setErrorMessages([]);
-        setIsApplying(true);
+    /**
+     * Performs an update of the internal addresses state
+     *
+     * When the "Static" boot protocol is currently selected, it ensures that there is at least one
+     * {@link module:/model~AddressConfig} in the collection, which helps displaying needed fields
+     * in the UI.
+     *
+     * @param {Array<module:model~AddressConfig>} [nextAddresses] - Addresses be used for the
+     *   update. When not given, current addresses will be used.
+     */
+    const forceAddressesUpdate = (nextAddresses) => {
+        nextAddresses ||= addresses;
 
+        if (bootProto === bootProtocol.STATIC && nextAddresses.length === 0) {
+            nextAddresses = [createAddressConfig()];
+        }
+
+        setAddresses(nextAddresses);
+    };
+
+    /**
+     * Performs validations using given addresses
+     *
+     * @param {Array<module:model~AddressConfig>} sanitizedAddresses - a collection of sanitize
+     *   addresses. See {@link sanitize}
+     * @return {boolean} true when all validations success; false otherwise
+     */
+    const validate = (sanitizedAddresses) => {
         /**
          * TODO: improve validations
          * TODO: highlight addresses with errors?
          */
+        let result = true;
         const errors = [];
-        const sanitizedAddresses = sanitize(addresses);
+
+        // Clean previous error messages
+        setErrorMessages([]);
+
+        if (bootProto === bootProtocol.STATIC && sanitizedAddresses.length === 0) {
+            result = false;
+            errors.push(
+                format(
+                    _('At least one address must be provided when using the "$bootProto" boot protocol'),
+                    { bootProto: bootProtocol.label(bootProtocol.STATIC) }
+                )
+            );
+        }
 
         if (findInvalidIP(sanitizedAddresses)) {
+            result = false;
             errors.push(_("There are invalid IPs"));
         }
 
         if (findRepeatedLabel(sanitizedAddresses)) {
+            result = false;
             errors.push(_("There are repeated labels"));
         }
 
+        setErrorMessages(errors);
+
+        return result;
+    };
+
+    /**
+     * Handles the form submit, performing a connection update when proceed
+     *
+     * @see {@link validate}
+     * @see {@link module/NetworkContext~updateConnection}
+     */
+    const handleSubmit = () => {
+        setIsApplying(true);
+
+        const sanitizedAddresses = sanitize(addresses);
+
         // Do not proceed if errors were found
-        if (errors.length) {
-            setAddresses(sanitizedAddresses);
-            setErrorMessages(errors);
+        if (!validate(sanitizedAddresses)) {
+            forceAddressesUpdate(sanitizedAddresses);
             setIsApplying(false);
             return;
         }
@@ -112,18 +198,33 @@ const IPSettingsForm = ({ ipVersion = 'ipv4', connection, isOpen, onClose }) => 
                 });
     };
 
+    /**
+     * Updates the UI according to the bootProtocol selected
+     *
+     * Basically, setting the internal form state in order to ensure that the AddressDataList
+     * component displays the fields for at least one {@link module/model~AddressConfig} item.
+     */
+    useEffect(() => {
+        forceAddressesUpdate();
+        setAddressRequired(bootProto === bootProtocol.STATIC);
+    }, [bootProto]);
+
+    /**
+     * Renders error messages in an Patternfly/Alert component, if any
+     */
     const renderErrors = () => {
         if (errorMessages.length === 0) return null;
 
-        return errorMessages.map((error, idx) => (
+        return (
             <Alert
-key={idx}
-              variant="danger"
-              title={error}
-              aria-live="polite"
               isInline
-            />
-        ));
+              variant="danger"
+              aria-live="polite"
+              title={_("Data is not valid, please check it")}
+            >
+                {errorMessages.map(error => <p>{error}</p>)}
+            </Alert>
+        );
     };
 
     return (
@@ -134,11 +235,11 @@ key={idx}
             onClose={onClose}
             actions={[
                 <Button
-              spinnerAriaValueText={isApplying ? _("Applying changes") : undefined}
-              isLoading={isApplying}
-              isDisabled={isApplying}
-              key="confirm" variant="primary"
-              onClick={handleSubmit}
+                  spinnerAriaValueText={isApplying ? _("Applying changes") : undefined}
+                  isLoading={isApplying}
+                  isDisabled={isApplying}
+                  key="confirm" variant="primary"
+                  onClick={handleSubmit}
                 >
                     {isApplying ? _("Applying changes") : _("Apply")}
                 </Button>,
@@ -155,7 +256,11 @@ key={idx}
                 </FormGroup>
 
                 <FormGroup label={_("Addresses")}>
-                    <AddressesDataList addresses={addresses} updateAddresses={setAddresses} />
+                    <AddressesDataList
+                      addresses={addresses}
+                      updateAddresses={setAddresses}
+                      allowEmpty={!addressRequired}
+                    />
                 </FormGroup>
             </Form>
         </Modal>

--- a/src/components/IPSettingsForm.js
+++ b/src/components/IPSettingsForm.js
@@ -179,23 +179,14 @@ const IPSettingsForm = ({ connection, ipVersion = 'ipv4', isOpen, onClose }) => 
             return;
         }
 
-        // If everything looks good, try to apply requested changes
-        const promise = updateConnection(
+        // If everything looks good, send requested changes and close
+        updateConnection(
             dispatch,
             connection,
             { [ipVersion]: { bootProto, addresses: sanitizedAddresses } }
         );
 
-        promise
-                .then(() => {
-                    setIsApplying(false);
-                    onClose();
-                })
-                .catch((error) => {
-                    console.error(error);
-                    setErrorMessages([_("Something went wrong. Please, try it again.")]);
-                    setIsApplying(false);
-                });
+        onClose();
     };
 
     /**

--- a/src/components/IPSettingsForm.js
+++ b/src/components/IPSettingsForm.js
@@ -101,11 +101,11 @@ const IPSettingsForm = ({ connection, ipVersion = 'ipv4', isOpen, onClose }) => 
     /**
      * Performs an update of the internal addresses state
      *
-     * When the "Static" boot protocol is currently selected, it ensures that there is at least one
-     * {@link module:/model~AddressConfig} in the collection, which helps displaying needed fields
-     * in the UI.
+     * When the "Static" boot protocol is selected, it ensures that there is at least one {@link
+     * module:/model~AddressConfig} in the collection, which helps displaying needed fields in the
+     * UI.
      *
-     * @param {Array<module:model~AddressConfig>} [nextAddresses] - Addresses be used for the
+     * @param {Array<module:model~AddressConfig>} [nextAddresses] - Addresses to be used for the
      *   update. When not given, current addresses will be used.
      */
     const forceAddressesUpdate = (nextAddresses) => {

--- a/src/components/IPSettingsLink.js
+++ b/src/components/IPSettingsLink.js
@@ -31,8 +31,17 @@ const IPSettingsLink = ({ ipVersion = 'ipv4', connection }) => {
     const [isFormOpen, setFormOpen] = useState(false);
 
     const renderLinkText = () => {
-        const bootProto = connection[ipVersion].bootProto;
-        return bootProto ? bootProtocol.label(bootProto) : _("Not configured");
+        const { bootProto, addresses } = connection[ipVersion];
+
+        if (!bootProto) return _("Not configured");
+
+        const bootProtoLabel = bootProtocol.label(bootProto);
+
+        if (bootProto === bootProtocol.STATIC) {
+            return [bootProtoLabel, addresses[0].local].join(" - ");
+        }
+
+        return bootProtoLabel;
     };
 
     const renderForm = () => {
@@ -50,7 +59,7 @@ const IPSettingsLink = ({ ipVersion = 'ipv4', connection }) => {
 
     return (
         <>
-            <Button variant="link" onClick={() => setFormOpen(true)}>{renderLinkText()}</Button>
+            <a href="#" onClick={() => setFormOpen(true)}>{renderLinkText()}</a>
             {renderForm()}
         </>
     );

--- a/src/lib/model/index.js
+++ b/src/lib/model/index.js
@@ -161,16 +161,22 @@ const propsByConnectionType = {
 };
 
 /**
+ * @typedef {Object} AddressConfig
+ * @property {string} type - Address type ('IPv4' or 'IPv6')
+ * @property {string} local - Local IP address
+ * @property {string} label - IP label
+ */
+
+/**
  * @function
  *
  * Returns an address configuration object
  *
  * @param {object} args - Configuration attributes
  * @param {string} args.type - Address type ('IPv4' or 'IPv6')
- * @param {string} args.proto - Boot protocol ('DHCP', 'STATIC', etc.)
  * @param {string} args.local - Local IP address
  * @param {string} args.label - IP label
- * @return {object}
+ * @return {AddressConfig}
  * @todo The IP address deserves its own type
  */
 export const createAddressConfig = ({


### PR DESCRIPTION
Related to #27, 

* the boot protocol selector displays only the options supported by wicked

* the interfaces list renders more complete information in the interface summary

  ![Screenshot_2020-11-04 Wicked - ytm 10 0 0 204](https://user-images.githubusercontent.com/1691872/98094340-0f39e900-1e81-11eb-9592-fb13fa6ef88c.png)

* the form behavior when the `STATIC` boot protocol is selected have been improved

  | Static + one address | Static + multiple addresses | Not static + one address |
  |-|-|-|
  | ![Screenshot_2020-11-04 Wicked - ytm 10 0 0 204(1)](https://user-images.githubusercontent.com/1691872/98094688-84a5b980-1e81-11eb-854b-5d364062e69b.png) | ![Screenshot_2020-11-04 Wicked - ytm 10 0 0 204(2)](https://user-images.githubusercontent.com/1691872/98094718-8bccc780-1e81-11eb-8880-d4acf84cd001.png) |  ![Screenshot_2020-11-04 Wicked - ytm 10 0 0 204(3)](https://user-images.githubusercontent.com/1691872/98094742-94250280-1e81-11eb-9c56-65330abd5c52.png) |
  | No delete action present | Delete action present  | Delete action present |


