### PR TITLE
Fix forms

### DIFF
--- a/src/components/BondForm.js
+++ b/src/components/BondForm.js
@@ -70,15 +70,12 @@ const BondForm = ({ isOpen, onClose, connection }) => {
                 options
             }
         };
-        let promise = null;
 
         if (isEditing) {
-            promise = updateConnection(dispatch, connection, bondingAttrs);
+            updateConnection(dispatch, connection, bondingAttrs);
         } else {
-            promise = addConnection(dispatch, { ...bondingAttrs, type: interfaceType.BONDING });
+            addConnection(dispatch, { ...bondingAttrs, type: interfaceType.BONDING });
         }
-
-        promise.then(onClose).catch(console.error);
     };
 
     const closeForm = () => {

--- a/src/components/BridgeForm.js
+++ b/src/components/BridgeForm.js
@@ -46,7 +46,7 @@ const BridgeForm = ({ isOpen, onClose, connection }) => {
 
     useEffect(() => {
         if (isEditing) {
-            setCandidatePorts(Object.values(interfaces).filter(i => i.id !== connection.id));
+            setCandidatePorts(Object.values(interfaces).filter(i => i.name !== connection.name));
         } else {
             setCandidatePorts(Object.values(interfaces));
         }

--- a/src/components/BridgeForm.js
+++ b/src/components/BridgeForm.js
@@ -53,19 +53,15 @@ const BridgeForm = ({ isOpen, onClose, connection }) => {
     }, [connection, isEditing, interfaces]);
 
     const addOrUpdateConnection = () => {
-        let promise = null;
-
         if (isEditing) {
-            promise = updateConnection(
+            updateConnection(
                 dispatch, connection, { name, bridge: { ports: selectedPorts } }
             );
         } else {
-            promise = addConnection(
+            addConnection(
                 dispatch, { name, type: interfaceType.BRIDGE, bridge: { ports: selectedPorts, } }
             );
         }
-
-        promise.then(onClose).catch(console.error);
     };
 
     const handleSelectedPorts = (name) => (value) => {

--- a/src/components/StartMode.js
+++ b/src/components/StartMode.js
@@ -36,35 +36,43 @@ const StartMode = ({ connection }) => {
     const [startMode, setStartMode] = useState(connection.startMode);
     const dispatch = useNetworkDispatch();
 
-    function handleSubmit() {
+    const closeForm = () => setModal(false);
+
+    const handleSubmit = () => {
         // TODO: notify that something went wrong.
         updateConnection(dispatch, connection, { startMode })
-                .then(() => setModal(false))
-                .catch(console.log);
+        closeForm();
+    }
+
+    const renderModal = () => {
+      return (
+          <Modal
+              variant={ModalVariant.small}
+              title={_("Start Mode")}
+              isOpen={modal}
+              onClose={closeForm}
+              actions={[
+                  <Button key="confirm" variant="primary" onClick={handleSubmit}>
+                      {_("Change")}
+                  </Button>,
+                  <Button key="cancel" variant="link" onClick={closeForm}>
+                      {_("Cancel")}
+                  </Button>
+              ]}
+          >
+              <FormSelect value={startMode} onChange={setStartMode} id="startMode">
+                  {startModeOptions.map((option, index) => (
+                      <FormSelectOption key={index} value={option.value} label={option.label} />
+                  ))}
+              </FormSelect>
+          </Modal>
+      )
     }
 
     return (
         <>
             <a href="#" onClick={() => setModal(true)}>{startModeEnum.label(connection.startMode)}</a>
-            <Modal
-                variant={ModalVariant.small}
-                title={_("Start Mode")}
-                isOpen={modal}
-                actions={[
-                    <Button key="confirm" variant="primary" onClick={handleSubmit}>
-                        {_("Change")}
-                    </Button>,
-                    <Button key="cancel" variant="link" onClick={() => setModal(false)}>
-                        {_("Cancel")}
-                    </Button>
-                ]}
-            >
-                <FormSelect value={startMode} onChange={setStartMode} id="startMode">
-                    {startModeOptions.map((option, index) => (
-                        <FormSelectOption key={index} value={option.value} label={option.label} />
-                    ))}
-                </FormSelect>
-            </Modal>
+            { modal && renderModal() }
         </>
     );
 };

--- a/src/components/VlanForm.js
+++ b/src/components/VlanForm.js
@@ -57,15 +57,11 @@ const VlanForm = ({ isOpen, onClose, connection }) => {
     }, [vlanId, parentDevice]);
 
     const addOrUpdateConnection = () => {
-        let promise = null;
-
         if (isEditing) {
-            promise = updateConnection(dispatch, connection, { vlan: { name, vlanId, parentDevice } });
+            updateConnection(dispatch, connection, { vlan: { name, vlanId, parentDevice } });
         } else {
-            promise = addConnection(dispatch, { name, type: interfaceType.VLAN, vlan: { vlanId, parentDevice } });
+            addConnection(dispatch, { name, type: interfaceType.VLAN, vlan: { vlanId, parentDevice } });
         }
-
-        promise.then(onClose).catch(console.error);
     };
 
     const isIncomplete = () => {

--- a/src/lib/wicked/connections.js
+++ b/src/lib/wicked/connections.js
@@ -152,7 +152,7 @@ const propsByConnectionType = {
     },
     [interfaceType.BRIDGE]: ({ bridge }) => {
         const { ports } = bridge;
-        return { bridge: { ports } };
+        return { bridge: { ports: ports.map((p) => p.device) } };
     },
     [interfaceType.VLAN]: ({ vlan }) => {
         const { tag, device } = vlan;

--- a/src/lib/wicked/connections.test.js
+++ b/src/lib/wicked/connections.test.js
@@ -71,7 +71,7 @@ describe('#createConnection', () => {
             name: 'br0',
             bridge: {
                 stp: true,
-                ports: ['eth0', 'eth1']
+                ports: [{ device: 'eth0' }, { device: 'eth1' }]
             }
 
         };


### PR DESCRIPTION
This PR fixes some issues in the current forms.

Also stop waiting for the response of the action when requesting changes. Instead, close the form immediately to follow the approach proposed in #28 

> Wicked's D-Bus interface notifies status changes. The idea is to listen for those changes and notify them to the React application to change the current status.

Of course, these forms should implement needed validations (if any) before sending the changes.

Additionally, parses bridge ports as expected. See https://github.com/dgdavid/cockpit-wicked/pull/36/commits/0b6dbf7f0a676e53c9940039b7f1c24909eed322