### PR TITLE
Parse routes files

### DIFF
--- a/src/components/RouteForm.js
+++ b/src/components/RouteForm.js
@@ -22,7 +22,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button, Checkbox, Form, FormGroup, Modal, ModalVariant, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
 import cockpit from 'cockpit';
-import { useNetworkDispatch, useNetworkState, actionTypes } from '../context/network';
+import { useNetworkDispatch, useNetworkState, actionTypes, addRoute, updateRoute } from '../context/network';
 
 const _ = cockpit.gettext;
 
@@ -33,7 +33,7 @@ const RouteForm = ({ isOpen, onClose, route }) => {
     const [destination, setDestination] = useState(route?.destination || "");
     const [device, setDevice] = useState(route?.device || "");
     const [options, setOptions] = useState(route?.options || "");
-    const { interfaces } = useNetworkState();
+    const { interfaces, routes } = useNetworkState();
     const [candidateInterfaces, setCandidateInterfaces] = useState([]);
     const dispatch = useNetworkDispatch();
 
@@ -41,27 +41,14 @@ const RouteForm = ({ isOpen, onClose, route }) => {
         setCandidateInterfaces([{ name: "" }, ...Object.values(interfaces)]);
     }, [interfaces]);
 
-    const updateRoute = () => {
-        dispatch({
-            type: actionTypes.UPDATE_ROUTE,
-            payload: { id: route.id, changes: buildRouteData() }
-        });
-    };
-
     const addOrUpdateRoute = () => {
         if (isEditing) {
-            updateRoute();
+            updateRoute(dispatch, routes, route.id, buildRouteData());
         } else {
-            addRoute();
+            addRoute(dispatch, routes, buildRouteData());
         }
-        onClose();
-    };
 
-    const addRoute = () => {
-        dispatch({
-            type: actionTypes.ADD_ROUTE,
-            payload: buildRouteData()
-        });
+        onClose();
     };
 
     const buildRouteData = () => {

--- a/src/components/RoutesList.js
+++ b/src/components/RoutesList.js
@@ -23,7 +23,7 @@ import cockpit from "cockpit";
 import React, { useState, useEffect } from 'react';
 import { Card, CardBody } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, TableVariant } from '@patternfly/react-table';
-import { useNetworkDispatch, updateRoutes } from '../context/network';
+import { useNetworkDispatch, deleteRoute } from '../context/network';
 import RouteForm from './RouteForm';
 
 const _ = cockpit.gettext;
@@ -51,8 +51,10 @@ const RoutesList = ({ routes }) => {
         setFormOpen(true);
     };
 
-    const deleteRoute = (event, rowId) => {
-        updateRoutes(dispatch, routes.filter((value, index) => index !== rowId));
+    // FIXME
+    const removeRoute = (event, rowId) => {
+        const route = routes.find((_route, index) => index === rowId);
+        deleteRoute(dispatch, routes, route.id);
     };
 
     const actions = [
@@ -62,7 +64,7 @@ const RoutesList = ({ routes }) => {
         },
         {
             title: _("Delete"),
-            onClick: deleteRoute
+            onClick: removeRoute
         }
     ];
 

--- a/src/components/RoutesList.js
+++ b/src/components/RoutesList.js
@@ -23,7 +23,7 @@ import cockpit from "cockpit";
 import React, { useState, useEffect } from 'react';
 import { Card, CardBody } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, TableVariant } from '@patternfly/react-table';
-import { useNetworkDispatch } from '../context/network';
+import { useNetworkDispatch, updateRoutes } from '../context/network';
 import RouteForm from './RouteForm';
 
 const _ = cockpit.gettext;
@@ -52,7 +52,7 @@ const RoutesList = ({ routes }) => {
     };
 
     const deleteRoute = (event, rowId) => {
-        dispatch({ type: 'set_routes', payload: routes.filter((value, index) => index !== rowId) });
+        updateRoutes(dispatch, routes.filter((value, index) => index !== rowId));
     };
 
     const actions = [

--- a/src/context/network.js
+++ b/src/context/network.js
@@ -205,6 +205,24 @@ async function updateConnection(dispatch, connection, changes) {
     return await networkClient().updateConnection(updatedConn);
 }
 
+
+/**
+ * Updates routes using the NetworkClient
+ *
+ * It dispatches the SET_ROUTES action.
+ *
+ * @todo Notify when something went wrong.
+ *
+ * @param {function} dispatch - Dispatch function
+ * @param {Array<module:model/routes~Route>} routes - Routes to update
+ * @return {Promise}
+ */
+async function updateRoutes(dispatch, routes) {
+    await networkClient().updateRoutes(routes);
+    const nextRoutes = await networkClient().getRoutes();
+    dispatch({ type: SET_ROUTES, payload: nextRoutes });
+}
+
 /**
  * Fetches the interfaces using the NetworkClient
  *
@@ -271,6 +289,7 @@ export {
     fetchInterfaces,
     fetchConnections,
     fetchRoutes,
+    updateRoutes,
     listenToInterfacesChanges,
     resetClient
 };

--- a/src/lib/NetworkClient.js
+++ b/src/lib/NetworkClient.js
@@ -90,8 +90,8 @@ class NetworkClient {
      * @param {Array<Object>} connections - List of routes to update
      * @returns {Promise<Array|Error>} Resolves to an array of connection objects in case of success
      */
-    updateRoutes(routes) {
-        return new Promise((resolve, reject) => resolve([]));
+    async updateRoutes(routes) {
+        return await this.adapter.updateRoutes(routes);
     }
 
     getEssidList(iface) {

--- a/src/lib/NetworkClient.js
+++ b/src/lib/NetworkClient.js
@@ -57,8 +57,8 @@ class NetworkClient {
      *
      * @returns {Promise<Array|Error>} Resolves to an array of objects in case of success
      */
-    getRoutes() {
-        return new Promise((resolve, reject) => resolve([]));
+    async getRoutes() {
+        return await this.adapter.routes();
     }
 
     addConnection(connection) {

--- a/src/lib/model/routes.js
+++ b/src/lib/model/routes.js
@@ -19,6 +19,12 @@
  * find current contact information at www.suse.com.
  */
 
+/**
+ * This module offers a set of factory functions for working with routes.
+ *
+ * @module model/routes
+ */
+
 let routeIndex = 0;
 
 /**

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -137,22 +137,28 @@ class WickedAdapter {
     /**
      * Update route files
      *
-     *
      * @param {Array} routes - routes to update
      * @return {Promise<Connection,Error>} Promise that resolve to the added connection
      */
     async updateRoutes(routes) {
         const NO_DEVICE_KEY = "none";
 
-        const routesByDevice = routes.reduce((routes, route) => {
+        // Include all knows interface to ensure successful deletions
+        const ifaces = await this.interfaces();
+        let routesByDevice = ifaces.reduce((result, iface) => {
+          result[iface.name] = [];
+          return result;
+        }, {})
+
+        // Collect routes by device
+        Object.values(routes).forEach((route) => {
             const key = route.device || NO_DEVICE_KEY;
-            routes[key] ||= [];
-            routes[key].push(route);
-            return routes;
-        }, {});
+            routesByDevice[key] ||= [];
+            routesByDevice[key].push(route);
+        });
 
+        // Write route files
         const promises = [];
-
         Object.keys(routesByDevice)
                 .forEach(k => {
                     const device = k !== NO_DEVICE_KEY ? k : undefined;

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -23,7 +23,7 @@ import Client from './client';
 import { createConnection } from './connections';
 import { createInterface } from './interfaces';
 import model from '../model';
-import { IfcfgFile } from './files';
+import { IfcfgFile, IfrouteFile } from './files';
 
 /**
  * This class is responsible for retrieving and updating Wicked's configuration.
@@ -89,6 +89,21 @@ class WickedAdapter {
             const data = (signal === 'deviceDelete') ? { ...iface, link: false } : iface;
             fn(signal, createInterface(data));
         });
+    }
+
+    async routes() {
+        let result = [];
+
+        const ifaces = await this.interfaces();
+        const files = ["routes"].concat(ifaces.map(iface => `ifroute-${iface.name}`));
+
+        for (const file of files) {
+          const routesFile = new IfrouteFile(`/etc/sysconfig/network/${file}`);
+          const routes = await routesFile.read();
+          result = result.concat(routes)
+        }
+
+        return result;
     }
 
     /**

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -145,10 +145,10 @@ class WickedAdapter {
 
         // Include all knows interface to ensure successful deletions
         const ifaces = await this.interfaces();
-        let routesByDevice = ifaces.reduce((result, iface) => {
-          result[iface.name] = [];
-          return result;
-        }, {})
+        const routesByDevice = ifaces.reduce((result, iface) => {
+            result[iface.name] = [];
+            return result;
+        }, {});
 
         // Collect routes by device
         Object.values(routes).forEach((route) => {

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -138,8 +138,8 @@ class WickedAdapter {
      * Update route files
      *
      *
-     * @param {Array<module:model/routes~Route>} routes - routes to update
-     * @return {Promise<Connection,Error>}
+     * @param {Array} routes - routes to update
+     * @return {Promise<Connection,Error>} Promise that resolve to the added connection
      */
     async updateRoutes(routes) {
         const NO_DEVICE_KEY = "none";

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -135,6 +135,35 @@ class WickedAdapter {
     }
 
     /**
+     * Update route files
+     *
+     *
+     * @param {Array<module:model/routes~Route>} routes - routes to update
+     * @return {Promise<Connection,Error>}
+     */
+    async updateRoutes(routes) {
+        const NO_DEVICE_KEY = "none";
+
+        const routesByDevice = routes.reduce((routes, route) => {
+            const key = route.device || NO_DEVICE_KEY;
+            routes[key] ||= [];
+            routes[key].push(route);
+            return routes;
+        }, {});
+
+        const promises = [];
+
+        Object.keys(routesByDevice)
+                .forEach(k => {
+                    const device = k !== NO_DEVICE_KEY ? k : undefined;
+                    const promise = new IfrouteFile(device).update(routesByDevice[k]);
+                    promises.push(promise);
+                });
+
+        return Promise.all(promises);
+    }
+
+    /**
      * Update the configuration file of a connection
      *
      * @param {Connection} connection - Connection to update

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -92,15 +92,13 @@ class WickedAdapter {
     }
 
     async routes() {
-        let result = [];
+        let result = await new IfrouteFile().read();
 
         const ifaces = await this.interfaces();
-        const files = ["routes"].concat(ifaces.map(iface => `ifroute-${iface.name}`));
 
-        for (const file of files) {
-          const routesFile = new IfrouteFile(`/etc/sysconfig/network/${file}`);
-          const routes = await routesFile.read();
-          result = result.concat(routes)
+        for (const iface of ifaces) {
+            const ifaceRoutes = await new IfrouteFile(iface.name).read();
+            result = result.concat(ifaceRoutes);
         }
 
         return result;

--- a/src/lib/wicked/files.js
+++ b/src/lib/wicked/files.js
@@ -166,8 +166,6 @@ class IfrouteParser {
     }
 
     parse(content) {
-        if (!content) return [];
-
         // Replace multiple spaces and tabs with a single space before split the content
         const lines = content.replace(/[ |\t]+/g, ' ').split(/\n/);
 

--- a/src/lib/wicked/files.js
+++ b/src/lib/wicked/files.js
@@ -161,10 +161,6 @@ class IfcfgFile {
  * @todo Add support for writing the content.
  */
 class IfrouteParser {
-    constructor(device) {
-        this.device = device;
-    }
-
     parse(content) {
         // Replace multiple spaces and tabs with a single space before split the content
         const lines = content.replace(/[ |\t]+/g, ' ').split(/\n/);
@@ -182,7 +178,7 @@ class IfrouteParser {
                 destination: columns[0],
                 gateway:     columns[1],
                 netmask:     columns[2],
-                device:      columns[3] || this.device,
+                device:      columns[3],
                 options:     columns[4],
             });
 
@@ -210,12 +206,19 @@ class IfrouteFile {
 
         this.path = [BASE_PATH, device ? `ifroute-${device}` : "routes"].join("/");
         this.device = device;
-        this.parser = new IfrouteParser(device);
+        this.parser = new IfrouteParser;
     }
 
     async read() {
         const content = await cockpit.file(this.path, { syntax: this.parser }).read();
-        return content || [];
+        const result = content || [];
+
+        if (!this.device) return result;
+
+        return result.map((route) => {
+          route.device ||= this.device;
+          return route
+        });
     }
 }
 


### PR DESCRIPTION
Brings back the `Routing` tab by reading/parsing the routes files.

![Screenshot_2020-11-06 Wicked - ytm 10 0 0 204](https://user-images.githubusercontent.com/1691872/98341246-7a60f800-2006-11eb-95e4-aa9f6cc8bc50.png)

Introduced changes make possible to read/write from/to _routes_ and _ifroute-\<interface\>_ files and interact with them though the current interface. However, as discussed offline, they can be considered as a workaround and we are going to rethink how to do it better in next sprint.