### PR TITLE
UI improvements

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -22,7 +22,7 @@
 import React, { useState } from 'react';
 import InterfacesTab from './components/InterfacesTab';
 import RoutingTab from './components/RoutingTab';
-import { Tabs, Tab, TabTitleText } from '@patternfly/react-core';
+import { Page, Tabs, Tab, TabTitleText } from '@patternfly/react-core';
 import { NetworkProvider } from './context/network';
 import cockpit from 'cockpit';
 
@@ -37,14 +37,16 @@ export const Application = () => {
 
     return (
         <NetworkProvider>
-            <Tabs activeKey={activeTabKey} onSelect={handleTabClick}>
-                <Tab eventKey={0} title={<TabTitleText>{_("Interfaces")}</TabTitleText>}>
-                    <InterfacesTab />
-                </Tab>
-                <Tab eventKey={1} title={<TabTitleText>{_("Routing")}</TabTitleText>}>
-                    <RoutingTab />
-                </Tab>
-            </Tabs>
+            <Page id="network-configuration">
+                <Tabs activeKey={activeTabKey} onSelect={handleTabClick}>
+                    <Tab eventKey={0} title={<TabTitleText>{_("Interfaces")}</TabTitleText>}>
+                        <InterfacesTab />
+                    </Tab>
+                    <Tab eventKey={1} title={<TabTitleText>{_("Routing")}</TabTitleText>}>
+                        <RoutingTab />
+                    </Tab>
+                </Tabs>
+            </Page>
         </NetworkProvider>
     );
 };

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -38,7 +38,7 @@ export const Application = () => {
     return (
         <NetworkProvider>
             <Page id="network-configuration">
-                <Tabs activeKey={activeTabKey} onSelect={handleTabClick}>
+                <Tabs mountOnEnter activeKey={activeTabKey} onSelect={handleTabClick}>
                     <Tab eventKey={0} title={<TabTitleText>{_("Interfaces")}</TabTitleText>}>
                         <InterfacesTab />
                     </Tab>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -38,7 +38,7 @@ export const Application = () => {
     return (
         <NetworkProvider>
             <Page id="network-configuration">
-                <Tabs mountOnEnter activeKey={activeTabKey} onSelect={handleTabClick}>
+                <Tabs activeKey={activeTabKey} onSelect={handleTabClick}>
                     <Tab eventKey={0} title={<TabTitleText>{_("Interfaces")}</TabTitleText>}>
                         <InterfacesTab />
                     </Tab>

--- a/src/app.scss
+++ b/src/app.scss
@@ -6,6 +6,10 @@ p {
   padding: var(--pf-global--gutter);
 }
 
+.modal-form-caption {
+  margin-bottom: var(--pf-global--spacer--sm);
+}
+
 /**
  *  Place details definition list into a grid, with PF4-like style
  *

--- a/src/app.scss
+++ b/src/app.scss
@@ -2,6 +2,10 @@ p {
     font-weight: bold;
 }
 
+#network-configuration {
+  padding: var(--pf-global--gutter);
+}
+
 /**
  *  Place details definition list into a grid, with PF4-like style
  *

--- a/src/components/BondForm.js
+++ b/src/components/BondForm.js
@@ -20,21 +20,18 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import cockpit from 'cockpit';
 import {
-    Button,
     Checkbox,
-    Form,
     FormGroup,
     FormSelect,
     FormSelectOption,
-    Modal,
-    ModalVariant,
     TextInput
 } from '@patternfly/react-core';
-import cockpit from 'cockpit';
 import { useNetworkDispatch, useNetworkState, addConnection, updateConnection } from '../context/network';
 import interfaceType from '../lib/model/interfaceType';
 import bondingModes from '../lib/model/bondingMode';
+import ModalForm from './ModalForm';
 
 const _ = cockpit.gettext;
 
@@ -92,75 +89,68 @@ const BondForm = ({ isOpen, onClose, connection }) => {
     };
 
     return (
-        <Modal
-            variant={ModalVariant.small}
+        <ModalForm
+            caption={connection?.name}
             title={isEditing ? _("Edit Bond") : _("Add Bond")}
             isOpen={isOpen}
-            onClose={onClose}
-            actions={[
-                <Button key="confirm" variant="primary" onClick={addOrUpdateConnection} isDisabled={isIncomplete()}>
-                    {isEditing ? _("Change") : _("Add")}
-                </Button>,
-                <Button key="cancel" variant="link" onClick={onClose}>
-                    {_("Cancel")}
-                </Button>
-            ]}
+            onCancel={onClose}
+            onSubmit={addOrUpdateConnection}
+            onSubmitDisable={isIncomplete()}
+            onSubmitLabel={isEditing ? _("Change") : _("Add")}
         >
-            <Form>
-                <FormGroup
-                    label={_("Name")}
+            <FormGroup
+                label={_("Name")}
+                isRequired
+                fieldId="interface-name"
+                helperText={_("Please, provide the interface name (e.g., bond0)")}
+            >
+                <TextInput
                     isRequired
-                    fieldId="interface-name"
-                    helperText={_("Please, provide the interface name (e.g., bond0)")}
-                >
-                    <TextInput
-                        isRequired
-                        id="interface-name"
-                        value={name}
-                        onChange={setName}
-                    />
-                </FormGroup>
+                    id="interface-name"
+                    value={name}
+                    onChange={setName}
+                />
+            </FormGroup>
 
-                <FormGroup
-                    label={_("Interfaces")}
-                    isRequired
-                >
-                    {candidateInterfaces.map(({ name }) => (
-                        <Checkbox
-                            label={name}
-                            key={name}
-                            isChecked={selectedInterfaces.includes(name)}
-                            onChange={handleSelectedInterfaces(name)}
-                        />
+            <FormGroup
+                label={_("Interfaces")}
+                isRequired
+            >
+                {candidateInterfaces.map(({ name }) => (
+                    <Checkbox
+                        label={name}
+                        key={name}
+                        isChecked={selectedInterfaces.includes(name)}
+                        onChange={handleSelectedInterfaces(name)}
+                    />
+                ))}
+            </FormGroup>
+
+            <FormGroup
+                label={_("Mode")}
+                isRequired
+                fieldId="bonding-mode"
+            >
+                <FormSelect value={mode} onChange={setMode} id="bonding-mode">
+                    {modeOptions.map((option, index) => (
+                        <FormSelectOption key={index} {...option} />
                     ))}
-                </FormGroup>
+                </FormSelect>
+            </FormGroup>
 
-                <FormGroup
-                    label={_("Mode")}
+            <FormGroup
+                label={_("Options")}
+                fieldId="bond-options"
+                helperText={_("Use this field to provide more options using the key=value format")}
+            >
+                <TextInput
                     isRequired
-                    fieldId="bonding-mode"
-                >
-                    <FormSelect value={mode} onChange={setMode} id="bonding-mode">
-                        {modeOptions.map((option, index) => (
-                            <FormSelectOption key={index} {...option} />
-                        ))}
-                    </FormSelect>
-                </FormGroup>
-
-                <FormGroup
-                    label={_("Options")}
-                    fieldId="bond-options"
-                    helperText={_("Use this field to provide more options using the key=value format")}
-                >
-                    <TextInput
-                        isRequired
-                        id="bond-options"
-                        value={options}
-                        onChange={setOptions}
-                    />
-                </FormGroup>
-            </Form>
-        </Modal>
+                    id="bond-options"
+                    value={options}
+                    onChange={setOptions}
+                />
+            </FormGroup>
+        </ModalForm>
     );
 };
 

--- a/src/components/BridgeForm.js
+++ b/src/components/BridgeForm.js
@@ -20,18 +20,11 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import {
-    Button,
-    Checkbox,
-    Form,
-    FormGroup,
-    Modal,
-    ModalVariant,
-    TextInput
-} from '@patternfly/react-core';
+import { Checkbox, FormGroup, TextInput } from '@patternfly/react-core';
 import cockpit from 'cockpit';
 import { useNetworkDispatch, useNetworkState, addConnection, updateConnection } from '../context/network';
 import interfaceType from '../lib/model/interfaceType';
+import ModalForm from './ModalForm';
 
 const _ = cockpit.gettext;
 
@@ -78,50 +71,43 @@ const BridgeForm = ({ isOpen, onClose, connection }) => {
     };
 
     return (
-        <Modal
-            variant={ModalVariant.small}
+        <ModalForm
+            caption={connection?.name}
             title={isEditing ? _("Edit Bridge") : _("Add Bridge")}
             isOpen={isOpen}
-            onClose={onClose}
-            actions={[
-                <Button key="confirm" variant="primary" onClick={addOrUpdateConnection} isDisabled={isIncomplete()}>
-                    {isEditing ? _("Change") : _("Add")}
-                </Button>,
-                <Button key="cancel" variant="link" onClick={onClose}>
-                    {_("Cancel")}
-                </Button>
-            ]}
+            onCancel={onClose}
+            onSubmit={addOrUpdateConnection}
+            onSubmitLabel={isEditing ? _("Change") : _("Add")}
+            onSubmitDisable={isIncomplete()}
         >
-            <Form>
-                <FormGroup
-                    label={_("Name")}
+            <FormGroup
+                label={_("Name")}
+                isRequired
+                fieldId="interface-name"
+                helperText={_("Please, provide the interface name (e.g., br0)")}
+            >
+                <TextInput
                     isRequired
-                    fieldId="interface-name"
-                    helperText={_("Please, provide the interface name (e.g., br0)")}
-                >
-                    <TextInput
-                        isRequired
-                        id="interface-name"
-                        value={name}
-                        onChange={setName}
-                    />
-                </FormGroup>
+                    id="interface-name"
+                    value={name}
+                    onChange={setName}
+                />
+            </FormGroup>
 
-                <FormGroup
-                    label={_("Ports")}
-                    isRequired
-                >
-                    {candidatePorts.map(({ name }) => (
-                        <Checkbox
-                            label={name}
-                            key={name}
-                            isChecked={selectedPorts.includes(name)}
-                            onChange={handleSelectedPorts(name)}
-                        />
-                    ))}
-                </FormGroup>
-            </Form>
-        </Modal>
+            <FormGroup
+                label={_("Ports")}
+                isRequired
+            >
+                {candidatePorts.map(({ name }) => (
+                    <Checkbox
+                        label={name}
+                        key={name}
+                        isChecked={selectedPorts.includes(name)}
+                        onChange={handleSelectedPorts(name)}
+                    />
+                ))}
+            </FormGroup>
+        </ModalForm>
     );
 };
 

--- a/src/components/IPSettingsForm.js
+++ b/src/components/IPSettingsForm.js
@@ -21,22 +21,14 @@
 
 import React, { useState, useEffect } from 'react';
 import cockpit from 'cockpit';
+import { Alert, FormGroup, ModalVariant } from '@patternfly/react-core';
+import { useNetworkDispatch, updateConnection } from '../context/network';
+import { createAddressConfig } from '../lib/model/address';
 import { isValidIP } from '../lib/utils';
 import bootProtocol from '../lib/model/bootProtocol';
-import { createAddressConfig } from '../lib/model/address';
-
-import {
-    Alert,
-    Button,
-    Form,
-    FormGroup,
-    Modal,
-    ModalVariant
-} from '@patternfly/react-core';
-
-import { useNetworkDispatch, updateConnection } from '../context/network';
-import BootProtoSelector from "./BootProtoSelector";
-import AddressesDataList from "./AddressesDataList";
+import ModalForm from './ModalForm';
+import BootProtoSelector from './BootProtoSelector';
+import AddressesDataList from './AddressesDataList';
 
 const { gettext: _, format } = cockpit;
 
@@ -226,42 +218,28 @@ const IPSettingsForm = ({ connection, ipVersion = 'ipv4', isOpen, onClose }) => 
     };
 
     return (
-        <Modal
-            variant={ModalVariant.medium}
+        <ModalForm
+            caption={connection.name}
             title={_(`${ipVersion.toUpperCase()} Settings`)}
             isOpen={isOpen}
-            onClose={onClose}
-            actions={[
-                <Button
-                  spinnerAriaValueText={isApplying ? _("Applying changes") : undefined}
-                  isLoading={isApplying}
-                  isDisabled={isApplying}
-                  key="confirm" variant="primary"
-                  onClick={handleSubmit}
-                >
-                    {isApplying ? _("Applying changes") : _("Apply")}
-                </Button>,
-                <Button key="cancel" variant="link" onClick={onClose}>
-                    {_("Cancel")}
-                </Button>
-            ]}
+            onSubmit={handleSubmit}
+            onCancel={onClose}
+            variant={ModalVariant.medium}
         >
-            <Form>
-                {renderErrors()}
+            {renderErrors()}
 
-                <FormGroup label={_("Boot Protocol")} isRequired>
-                    <BootProtoSelector value={bootProto} onChange={setBootProto} />
-                </FormGroup>
+            <FormGroup label={_("Boot Protocol")} isRequired>
+                <BootProtoSelector value={bootProto} onChange={setBootProto} />
+            </FormGroup>
 
-                <FormGroup label={_("Addresses")}>
-                    <AddressesDataList
-                      addresses={addresses}
-                      updateAddresses={setAddresses}
-                      allowEmpty={!addressRequired}
-                    />
-                </FormGroup>
-            </Form>
-        </Modal>
+            <FormGroup label={_("Addresses")}>
+                <AddressesDataList
+                    addresses={addresses}
+                    updateAddresses={setAddresses}
+                    allowEmpty={!addressRequired}
+                />
+            </FormGroup>
+        </ModalForm>
     );
 };
 

--- a/src/components/IPSettingsForm.js
+++ b/src/components/IPSettingsForm.js
@@ -138,22 +138,29 @@ const IPSettingsForm = ({ connection, ipVersion = 'ipv4', isOpen, onClose }) => 
 
         if (bootProto === bootProtocol.STATIC && sanitizedAddresses.length === 0) {
             result = false;
-            errors.push(
-                format(
+            errors.push({
+                key: 'static-address-required',
+                message: format(
                     _('At least one address must be provided when using the "$bootProto" boot protocol'),
                     { bootProto: bootProtocol.label(bootProtocol.STATIC) }
                 )
-            );
+            });
         }
 
         if (findInvalidIP(sanitizedAddresses)) {
             result = false;
-            errors.push(_("There are invalid IPs"));
+            errors.push({
+                key: 'invalid-ips',
+                message: _("There are invalid IPs")
+            });
         }
 
         if (findRepeatedLabel(sanitizedAddresses)) {
             result = false;
-            errors.push(_("There are repeated labels"));
+            errors.push({
+                key: 'repeated-lables',
+                message: _("There are repeated labels")
+            });
         }
 
         setErrorMessages(errors);
@@ -213,7 +220,7 @@ const IPSettingsForm = ({ connection, ipVersion = 'ipv4', isOpen, onClose }) => 
               aria-live="polite"
               title={_("Data is not valid, please check it")}
             >
-                {errorMessages.map(error => <p>{error}</p>)}
+                {errorMessages.map(({ key, message }) => <p key={key}>{message}</p>)}
             </Alert>
         );
     };

--- a/src/components/IPSettingsForm.js
+++ b/src/components/IPSettingsForm.js
@@ -150,7 +150,7 @@ const IPSettingsForm = ({ connection, ipVersion = 'ipv4', isOpen, onClose }) => 
         if (findRepeatedLabel(sanitizedAddresses)) {
             result = false;
             errors.push({
-                key: 'repeated-lables',
+                key: 'repeated-labels',
                 message: _("There are repeated labels")
             });
         }

--- a/src/components/ModalForm.js
+++ b/src/components/ModalForm.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from 'react';
+import cockpit from 'cockpit';
+
+import {
+    ActionGroup,
+    Button,
+    Form,
+    Modal,
+    ModalVariant,
+    Text,
+    TextVariants,
+    Title
+} from '@patternfly/react-core';
+
+const _ = cockpit.gettext;
+
+/**
+ * General component for loading and displaying a form in a PF4/Modal
+ *
+ * @see {@link https://www.patternfly.org/v4/components/modal}
+ *
+ * @param {object} props - component props
+ * @param {string} [props.caption] - a caption to be shown before the modal title
+ * @param {string} [props.title] - the dialog/form title
+ * @param {boolean} [props.isOpen=false] - whether the dialog is open and form visible
+ * @param {function} props.onSubmit - callback to be triggered when the user "sent" the form
+ * @param {boolean} [props.onSubmitDisable=false] - whether the submit button is enable or not
+ * @param {string} [props.onSubmitLabel="Apply"] - text for the "submit" button
+ * @param {function} props.onCancel - callback to be triggered when the user "dismiss" the form
+ * @param {string} [props.onCancelLabel="Cancel"] - text for the "Cancel" button
+ * @param {string} [props.variant=ModalVariant.small] - Size of the modal. See PF4/ModalVariant
+ * @param {JSX.Element} props.children - content for the form
+ */
+const ModalForm = ({
+    caption,
+    title,
+    isOpen = false,
+    onSubmit,
+    onSubmitDisable = false,
+    onSubmitLabel = _("Apply"),
+    onCancel,
+    onCancelLabel = _("Cancel"),
+    variant = ModalVariant.small,
+    children
+}) => {
+    if (!isOpen) return;
+
+    return (
+        <Modal
+            aria-label={title}
+            variant={variant}
+            isOpen={isOpen}
+            showClose={false}
+            header={
+                <>
+                    <Text component={TextVariants.small} className='modal-form-caption'>
+                        {caption}
+                    </Text>
+                    <Title headingLevel="h1">
+                        {title}
+                    </Title>
+                </>
+            }
+            footer={
+                <ActionGroup>
+                    <Button key="submit" onClick={onSubmit} isDisabled={onSubmitDisable}>
+                        {onSubmitLabel}
+                    </Button>
+
+                    <Button key="cancel" variant="link" onClick={onCancel}>
+                        {onCancelLabel}
+                    </Button>
+                </ActionGroup>
+            }
+        >
+
+            <Form>
+                {children}
+            </Form>
+        </Modal>
+    );
+};
+
+export default ModalForm;

--- a/src/components/StartMode.js
+++ b/src/components/StartMode.js
@@ -20,10 +20,11 @@
  */
 
 import React, { useState } from 'react';
-import { Modal, ModalVariant, Button, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import cockpit from 'cockpit';
+import { FormSelect, FormSelectOption, ModalVariant } from '@patternfly/react-core';
 import { useNetworkDispatch, updateConnection } from '../context/network';
 import startModeEnum from '../lib/model/startMode';
-import cockpit from 'cockpit';
+import ModalForm from './ModalForm';
 
 const _ = cockpit.gettext;
 
@@ -32,11 +33,12 @@ const startModeOptions = startModeEnum.values.map(mode => {
 });
 
 const StartMode = ({ connection }) => {
-    const [modal, setModal] = useState(false);
+    const [isOpen, setIsOpen] = useState(false);
     const [startMode, setStartMode] = useState(connection.startMode);
     const dispatch = useNetworkDispatch();
 
-    const closeForm = () => setModal(false);
+    const closeForm = () => setIsOpen(false);
+    const openForm = () => setIsOpen(true);
 
     const handleSubmit = () => {
         // TODO: notify that something went wrong.
@@ -44,35 +46,29 @@ const StartMode = ({ connection }) => {
         closeForm();
     };
 
-    const renderModal = () => {
+    const renderModalForm = () => {
         return (
-            <Modal
-              variant={ModalVariant.small}
+            <ModalForm
+              caption={connection.name}
               title={_("Start Mode")}
-              isOpen={modal}
-              onClose={closeForm}
-              actions={[
-                  <Button key="confirm" variant="primary" onClick={handleSubmit}>
-                      {_("Change")}
-                  </Button>,
-                  <Button key="cancel" variant="link" onClick={closeForm}>
-                      {_("Cancel")}
-                  </Button>
-              ]}
+              variant={ModalVariant.small}
+              isOpen={isOpen}
+              onSubmit={handleSubmit}
+              onCancel={closeForm}
             >
                 <FormSelect value={startMode} onChange={setStartMode} id="startMode">
                     {startModeOptions.map((option, index) => (
                         <FormSelectOption key={index} value={option.value} label={option.label} />
                     ))}
                 </FormSelect>
-            </Modal>
+            </ModalForm>
         );
     };
 
     return (
         <>
-            <a href="#" onClick={() => setModal(true)}>{startModeEnum.label(connection.startMode)}</a>
-            { modal && renderModal() }
+            <a href="#" onClick={openForm}>{startModeEnum.label(connection.startMode)}</a>
+            { isOpen && renderModalForm() }
         </>
     );
 };

--- a/src/components/VlanForm.js
+++ b/src/components/VlanForm.js
@@ -20,19 +20,16 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import cockpit from 'cockpit';
 import {
-    Button,
-    Form,
     FormGroup,
     FormSelect,
     FormSelectOption,
-    Modal,
-    ModalVariant,
     TextInput,
 } from '@patternfly/react-core';
-import cockpit from 'cockpit';
 import { useNetworkDispatch, useNetworkState, addConnection, updateConnection } from '../context/network';
 import interfaceType from '../lib/model/interfaceType';
+import ModalForm from './ModalForm';
 
 const _ = cockpit.gettext;
 
@@ -86,63 +83,57 @@ const VlanForm = ({ isOpen, onClose, connection }) => {
     if (!parentDevice) return null;
 
     return (
-        <Modal
-            variant={ModalVariant.small}
+        <ModalForm
+            caption={connection?.name}
             title={isEditing ? _("Edit VLAN") : _("Add VLAN")}
             isOpen={isOpen}
-            onClose={onClose}
-            actions={[
-                <Button key="confirm" variant="primary" onClick={addOrUpdateConnection} isDisabled={isIncomplete()}>
-                    {isEditing ? _("Change") : _("Add")}
-                </Button>,
-                <Button key="cancel" variant="link" onClick={onClose}>
-                    {_("Cancel")}
-                </Button>
-            ]}
+            onCancel={onClose}
+            onSubmit={addOrUpdateConnection}
+            onSubmitLabel={isEditing ? _("Change") : _("Add")}
+            onSubmitDisable={isIncomplete()}
         >
-            <Form>
-                <FormGroup
-                    label={_("Parent")}
-                    isRequired
-                    fieldId="parentDevice"
-                >
+            <FormGroup
+                label={_("Parent")}
+                isRequired
+                fieldId="parentDevice"
+            >
 
-                    <FormSelect value={parentDevice} onChange={setParentDevice} id="parentDevice">
-                        {candidateInterfaces.map(({ name }) => (
-                            <FormSelectOption key={name} value={name} label={name} />
-                        ))}
-                    </FormSelect>
-                </FormGroup>
-                <FormGroup
-                    label={_("VLAN ID")}
-                    isRequired
-                    fieldId="vlan_id"
-                    helperText={_("Please, provide the VLAN ID (e.g., 10)")}
-                >
-                    <TextInput
-                        isRequired
-                        id="vlan_id"
-                        value={vlanId}
-                        onChange={setVlanId}
-                        type="number"
-                    />
-                </FormGroup>
+                <FormSelect value={parentDevice} onChange={setParentDevice} id="parentDevice">
+                    {candidateInterfaces.map(({ name }) => (
+                        <FormSelectOption key={name} value={name} label={name} />
+                    ))}
+                </FormSelect>
+            </FormGroup>
 
-                <FormGroup
-                    label={_("Name")}
+            <FormGroup
+                label={_("VLAN ID")}
+                isRequired
+                fieldId="vlan_id"
+                helperText={_("Please, provide the VLAN ID (e.g., 10)")}
+            >
+                <TextInput
                     isRequired
-                    fieldId="interface-name"
-                    helperText={_("Please, provide the interface name (e.g., vlan10)")}
-                >
-                    <TextInput
-                        isRequired
-                        id="interface-name"
-                        value={name}
-                        onChange={updateName}
-                    />
-                </FormGroup>
-            </Form>
-        </Modal>
+                    id="vlan_id"
+                    value={vlanId}
+                    onChange={setVlanId}
+                    type="number"
+                />
+            </FormGroup>
+
+            <FormGroup
+                label={_("Name")}
+                isRequired
+                fieldId="interface-name"
+                helperText={_("Please, provide the interface name (e.g., vlan10)")}
+            >
+                <TextInput
+                    isRequired
+                    id="interface-name"
+                    value={name}
+                    onChange={updateName}
+                />
+            </FormGroup>
+        </ModalForm>
     );
 };
 


### PR DESCRIPTION
This PR simply adds a few UI improvements

* Wraps the content in a page, with some content padding
  | Before | After |
  |-|-|
  | ![Screenshot_2020-11-11 Networking - ytm 10 0 0 204](https://user-images.githubusercontent.com/1691872/98801019-1cb71c00-2409-11eb-84b7-e3f567e6e3ab.png) | ![Screenshot_2020-11-11 Networking - ytm 10 0 0 204(3)](https://user-images.githubusercontent.com/1691872/98800984-10cb5a00-2409-11eb-8c39-69f5a6cd1719.png) |
  
* Use a generic _modal form_ for displaying the forms, adding an small _caption_ in the top left corner to somehow keep the _action context_.
   | Before | After |
   |-|-|
   | ![Screenshot_2020-11-11 Networking - ytm 10 0 0 204(1)](https://user-images.githubusercontent.com/1691872/98801149-4c662400-2409-11eb-8953-e4c1296eeb9d.png) | ![Screenshot_2020-11-11 Networking - ytm 10 0 0 204(2)](https://user-images.githubusercontent.com/1691872/98801166-5556f580-2409-11eb-9b12-85e0b5e0d68a.png) |


---

Note: better to review it commit by commit.

  