### PR TITLE
Fix default routes (and other minor improvements)

### DIFF
--- a/src/components/RouteForm.js
+++ b/src/components/RouteForm.js
@@ -97,8 +97,8 @@ const RouteForm = ({ isOpen, onClose, route }) => {
 
                 { !isDefault &&
                     <FormGroup
+                        isRequired
                         label={_("Destination")}
-                        isRequired={!isDefault}
                         fieldId="destination"
                         helperText={_("Destination")}
                     >
@@ -111,8 +111,8 @@ const RouteForm = ({ isOpen, onClose, route }) => {
                     </FormGroup>}
 
                 <FormGroup
-                    label={_("Gateway")}
                     isRequired
+                    label={_("Gateway")}
                     fieldId="gateway"
                 >
                     <TextInput
@@ -125,7 +125,6 @@ const RouteForm = ({ isOpen, onClose, route }) => {
 
                 <FormGroup
                     label={_("Device")}
-                    isRequired
                     fieldId="device"
                 >
                     <FormSelect value={device} onChange={setDevice} id="device">
@@ -134,13 +133,12 @@ const RouteForm = ({ isOpen, onClose, route }) => {
                         ))}
                     </FormSelect>
                 </FormGroup>
+
                 <FormGroup
                     label={_("Options")}
-                    isRequired
                     fieldId="options"
                 >
                     <TextInput
-                        isRequired
                         id="options"
                         value={options}
                         onChange={setOptions}

--- a/src/components/RouteForm.js
+++ b/src/components/RouteForm.js
@@ -22,7 +22,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button, Checkbox, Form, FormGroup, Modal, ModalVariant, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
 import cockpit from 'cockpit';
-import { useNetworkDispatch, useNetworkState, actionTypes, addRoute, updateRoute } from '../context/network';
+import { useNetworkDispatch, useNetworkState, addRoute, updateRoute } from '../context/network';
 
 const _ = cockpit.gettext;
 

--- a/src/components/RouteForm.js
+++ b/src/components/RouteForm.js
@@ -28,7 +28,7 @@ const _ = cockpit.gettext;
 
 const RouteForm = ({ isOpen, onClose, route }) => {
     const isEditing = !!route;
-    const [isDefault, setIsDefault] = useState(route?.isDefault);
+    const [isDefault, setIsDefault] = useState(route?.isDefault || false);
     const [gateway, setGateway] = useState(route?.gateway || "");
     const [destination, setDestination] = useState(route?.destination || "");
     const [device, setDevice] = useState(route?.device || "");
@@ -54,7 +54,7 @@ const RouteForm = ({ isOpen, onClose, route }) => {
     const buildRouteData = () => {
         return {
             isDefault,
-            destination: isDefault ? "" : destination,
+            destination: isDefault ? "default" : destination,
             gateway,
             device,
             options

--- a/src/components/RouteForm.js
+++ b/src/components/RouteForm.js
@@ -96,7 +96,7 @@ const RouteForm = ({ isOpen, onClose, route }) => {
         };
     };
 
-    const isInComplete = () => {
+    const isIncomplete = () => {
         if (!isDefault && destination.length == 0) return true;
         if (gateway.length == 0) return true;
 
@@ -151,8 +151,8 @@ const RouteForm = ({ isOpen, onClose, route }) => {
             onCancel={onClose}
             onSubmit={addOrUpdateRoute}
             onSubmitLabel={isEditing ? _("Change") : _("Add")}
+            onSubmitDisable={isIncomplete()}
         >
-            onSubmitDisable={isInComplete()}
             {renderErrors()}
 
             <FormGroup

--- a/src/components/RouteForm.js
+++ b/src/components/RouteForm.js
@@ -21,9 +21,10 @@
 
 import React, { useState, useEffect } from 'react';
 import cockpit from 'cockpit';
-import { Alert, Button, Checkbox, Form, FormGroup, Modal, ModalVariant, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
+import { Alert, Checkbox, FormGroup, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
 import { useNetworkDispatch, useNetworkState, addRoute, updateRoute } from '../context/network';
 import { isValidIP } from '../lib/utils';
+import ModalForm from './ModalForm';
 
 const _ = cockpit.gettext;
 
@@ -120,86 +121,88 @@ const RouteForm = ({ isOpen, onClose, route }) => {
         );
     };
 
+    /**
+     * Renders the destination input only when needed (i.e., route is not marked as a default)
+     */
+    const renderDestination = () => {
+        if (isDefault) return null;
+
+        return (
+            <FormGroup
+                isRequired
+                label={_("Destination")}
+                fieldId="destination"
+                helperText={_("Destination")}
+            >
+                <TextInput
+                    isRequired
+                    id="destination"
+                    value={destination}
+                    onChange={setDestination}
+                />
+            </FormGroup>
+        );
+    };
+
     return (
-        <Modal
-            variant={ModalVariant.small}
+        <ModalForm
             title={isEditing ? _("Edit Route") : _("Add Route")}
             isOpen={isOpen}
-            onClose={onClose}
-            actions={[
-                <Button key="confirm" variant="primary" onClick={addOrUpdateRoute} isDisabled={isInComplete()}>
-                    {isEditing ? _("Change") : _("Add")}
-                </Button>,
-                <Button key="cancel" variant="link" onClick={onClose}>
-                    {_("Cancel")}
-                </Button>
-            ]}
+            onCancel={onClose}
+            onSubmit={addOrUpdateRoute}
+            onSubmitLabel={isEditing ? _("Change") : _("Add")}
         >
-            <Form>
-                {renderErrors()}
+            onSubmitDisable={isInComplete()}
+            {renderErrors()}
 
-                <FormGroup
-                    label={_("Default route")}
-                    fieldId="isDefault"
-                >
-                    <Checkbox
-                        id="isDefault"
-                        isChecked={isDefault}
-                        onChange={setIsDefault}
-                    />
-                </FormGroup>
+            <FormGroup
+                label={_("Default route")}
+                fieldId="isDefault"
+            >
+                <Checkbox
+                    id="isDefault"
+                    isChecked={isDefault}
+                    onChange={setIsDefault}
+                />
+            </FormGroup>
 
-                { !isDefault &&
-                    <FormGroup
-                        isRequired
-                        label={_("Destination")}
-                        fieldId="destination"
-                        helperText={_("Destination")}
-                    >
-                        <TextInput
-                            isRequired
-                            id="destination"
-                            value={destination}
-                            onChange={setDestination}
-                        />
-                    </FormGroup>}
+            {renderDestination()}
 
-                <FormGroup
+            <FormGroup
+                isRequired
+                label={_("Gateway")}
+                fieldId="gateway"
+            >
+                <TextInput
                     isRequired
-                    label={_("Gateway")}
-                    fieldId="gateway"
-                >
-                    <TextInput
-                        isRequired
-                        id="gateway"
-                        value={gateway}
-                        onChange={setGateway}
-                    />
-                </FormGroup>
+                    id="gateway"
+                    value={gateway}
+                    onChange={setGateway}
+                />
+            </FormGroup>
 
-                <FormGroup
-                    label={_("Device")}
-                    fieldId="device"
-                >
-                    <FormSelect value={device} onChange={setDevice} id="device">
-                        {candidateInterfaces.map(({ name }, index) => (
-                            <FormSelectOption key={index} value={name} label={name} />
-                        ))}
-                    </FormSelect>
-                </FormGroup>
+            <FormGroup
+                label={_("Device")}
+                fieldId="device"
+            >
+                <FormSelect value={device} onChange={setDevice} id="device">
+                    {candidateInterfaces.map(({ name }, index) => (
+                        <FormSelectOption key={index} value={name} label={name} />
+                    ))}
+                </FormSelect>
+            </FormGroup>
 
-                <FormGroup
-                    label={_("Options")}
-                    fieldId="options"
-                >
-                    <TextInput
-                        id="options"
-                        value={options}
-                        onChange={setOptions}
-                    />
-                </FormGroup>
-            </Form>
-        </Modal>
+            <FormGroup
+                label={_("Options")}
+                fieldId="options"
+            >
+                <TextInput
+                    id="options"
+                    value={options}
+                    onChange={setOptions}
+                />
+            </FormGroup>
+        </ModalForm>
     );
 };
 

--- a/src/lib/model/routes.js
+++ b/src/lib/model/routes.js
@@ -53,7 +53,7 @@ let routeIndex = 0;
 export const createRoute = ({ isDefault, destination, gateway, device, options } = {}) => {
     return {
         id: routeIndex++,
-        isDefault,
+        isDefault: isDefault || destination === "default",
         destination,
         gateway,
         device,


### PR DESCRIPTION
The most important thing addressed in this PR is the fix for default routes, which must have a `default` destination instead of `-`. See  https://github.com/dgdavid/cockpit-wicked/commit/915ad5cdb10b24e03d6d72a15b6a35168cfcb5c8

But it includes some other minor improvements too, namely

* Fix what fields are marked as require
* Add a minimal/simple form validation
  
  ![Screenshot_2020-11-11 Networking - ytm 10 0 0 204(4)](https://user-images.githubusercontent.com/1691872/98836337-79cac600-2439-11eb-86f7-28e98c8c0238.png)

* Use the generic `ModalForm` component introduced in #48