### PR TITLE
Displays a message when wicked is not active

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -26,9 +26,9 @@ import {
     EmptyStateVariant,
     Page,
     Spinner,
-    Tabs,
     Tab,
     TabTitleText,
+    Tabs,
     Title
 } from '@patternfly/react-core';
 import { NetworkProvider, serviceIsActive } from './context/network';
@@ -46,8 +46,6 @@ export const Application = () => {
     const handleTabClick = (event, tabIndex) => {
         setActiveTabKey(tabIndex);
     };
-
-    const renderInactiveServicePage = () => <InactiveServicePage />;
 
     const renderTabs = () => {
         return (
@@ -82,7 +80,7 @@ export const Application = () => {
     return (
         <NetworkProvider>
             <Page id="network-configuration">
-                {serviceActive ? renderTabs() : renderInactiveServicePage()}
+                {serviceActive ? renderTabs() : <InactiveServicePage />}
             </Page>
         </NetworkProvider>
     );

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -22,16 +22,16 @@
 import React, { useState, useEffect } from 'react';
 import cockpit from 'cockpit';
 import {
-    EmptyState,
-    EmptyStateVariant,
     Page,
-    Spinner,
+    PageSection,
+    PageSectionVariants,
     Tab,
     TabTitleText,
     Tabs,
     Title
 } from '@patternfly/react-core';
 import { NetworkProvider, serviceIsActive } from './context/network';
+import StatusBar from './components/StatusBar';
 import InactiveServicePage from './components/InactiveServicePage';
 import InterfacesTab from './components/InterfacesTab';
 import RoutingTab from './components/RoutingTab';
@@ -39,7 +39,7 @@ import RoutingTab from './components/RoutingTab';
 const _ = cockpit.gettext;
 
 export const Application = () => {
-    const [loading, setLoading] = useState(true);
+    const [checkingService, setCheckingService] = useState(true);
     const [serviceReady, setServiceReady] = useState(false);
     const [activeTabKey, setActiveTabKey] = useState(0);
 
@@ -60,25 +60,28 @@ export const Application = () => {
         );
     };
 
+    const renderContent = () => {
+        if (checkingService) return null;
+        if (serviceReady) return renderTabs();
+        return <InactiveServicePage />;
+    };
+
     useEffect(() => {
         serviceIsActive()
                 .then(result => {
-                    setLoading(false);
+                    setCheckingService(false);
                     setServiceReady(result);
                 });
     }, []);
 
-    if (loading) return (
-        <EmptyState variant={EmptyStateVariant.full}>
-            <Spinner />
-            <Title headingLevel="h1" size="lg">{_("Loading...")}</Title>
-        </EmptyState>
-    );
-
     return (
         <NetworkProvider>
-            <Page id="network-configuration">
-                {serviceReady ? renderTabs() : <InactiveServicePage />}
+            <Page>
+                { checkingService && <StatusBar showSpinner>{_("Checking if service is active...")}</StatusBar> }
+
+                <PageSection padding={{ default: 'noPadding' }} variant={PageSectionVariants.light}>
+                    { renderContent() }
+                </PageSection>
             </Page>
         </NetworkProvider>
     );

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -39,9 +39,9 @@ import RoutingTab from './components/RoutingTab';
 const _ = cockpit.gettext;
 
 export const Application = () => {
-    const [activeTabKey, setActiveTabKey] = useState(0);
     const [loading, setLoading] = useState(true);
-    const [serviceActive, setServiceActive] = useState(true);
+    const [serviceReady, setServiceReady] = useState(false);
+    const [activeTabKey, setActiveTabKey] = useState(0);
 
     const handleTabClick = (event, tabIndex) => {
         setActiveTabKey(tabIndex);
@@ -61,13 +61,11 @@ export const Application = () => {
     };
 
     useEffect(() => {
-        const isActive = async () => {
-            const result = await serviceIsActive();
-            setLoading(false);
-            setServiceActive(result);
-        };
-
-        isActive();
+        serviceIsActive()
+                .then(result => {
+                    setLoading(false);
+                    setServiceReady(result);
+                });
     }, []);
 
     if (loading) return (
@@ -80,7 +78,7 @@ export const Application = () => {
     return (
         <NetworkProvider>
             <Page id="network-configuration">
-                {serviceActive ? renderTabs() : <InactiveServicePage />}
+                {serviceReady ? renderTabs() : <InactiveServicePage />}
             </Page>
         </NetworkProvider>
     );

--- a/src/app.scss
+++ b/src/app.scss
@@ -1,3 +1,7 @@
+#app {
+    height: 100%;
+}
+
 p {
     font-weight: bold;
 }

--- a/src/app.scss
+++ b/src/app.scss
@@ -6,9 +6,6 @@ p {
     font-weight: bold;
 }
 
-#network-configuration {
-  padding: var(--pf-global--gutter);
-}
 
 .modal-form-caption {
   margin-bottom: var(--pf-global--spacer--sm);

--- a/src/app.scss
+++ b/src/app.scss
@@ -52,3 +52,36 @@ p {
     padding-right: var(--pf-global--FontSize--xs);
   }
 }
+
+/**
+ * Try to make the status bar looks like in the packagekit module
+ *
+ * Borrowed from cockpit's file pkg/packagekit/updates.scss.
+ */
+.content-header-extra {
+    background: #f5f5f5;
+    border-bottom: 1px solid #ddd;
+    padding: 10px 20px;
+    width: 100%;
+    z-index: 900;
+    top: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    align-items: center;
+    min-height: 4rem;
+
+    @media screen and (min-width: 640px) {
+        position: sticky;
+    }
+
+    &--state {
+        /* Make the height similar to the button (2px padding + 1px border) */
+        padding: 3px 0;
+    }
+
+    &--state {
+        flex: 100 1 auto;
+        padding-right: 1ex;
+    }
+}

--- a/src/components/InactiveServicePage.js
+++ b/src/components/InactiveServicePage.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from 'react';
+import cockpit from 'cockpit';
+import {
+    Title,
+    Button,
+    EmptyState,
+    EmptyStateIcon,
+    EmptyStateBody,
+    EmptyStateSecondaryActions
+} from '@patternfly/react-core';
+import AlertIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+
+const _ = cockpit.gettext;
+
+/**
+ * General component to render an external link using a PF4/Button
+ *
+ * @example
+ *
+ *  <ExternalLink href="https://cockpit-project.org">
+ *      Cockpit Project Homepage
+ *  </ExternalLink>
+ *
+ * @param {object} props - component props
+ * @param {string} props.href - the url to be used as href
+ * @param {JSX.Element} props.children - content for the link
+ */
+const ExternalLink = ({ href, children }) => {
+    return (
+        <Button component="a" variant="link" target="_blank" href={href}>
+            {children}
+        </Button>
+    );
+};
+
+/**
+ * Page to be shown when wicked is not active
+ */
+const InactiveServicePage = () => {
+    return (
+        <EmptyState>
+            <EmptyStateIcon icon={AlertIcon} />
+            <Title headingLevel="h4" size="lg">
+                {_("Wicked service is not active")}
+            </Title>
+            <EmptyStateBody>
+                <p>
+                    {_(`Seems that wicked service is not active. It could be either, the service is
+                    not running or wicked is not installed.`)}
+                </p>
+                <p>
+                    {_("For more help, please check the documentation linked below.")}
+                </p>
+            </EmptyStateBody>
+
+            <EmptyStateSecondaryActions>
+                <ExternalLink href="https://en.opensuse.org/Portal:Wicked">
+                    openSUSE Wicked Portal
+                </ExternalLink>
+                <ExternalLink href="https://github.com/openSUSE/wicked/wiki/FAQ">
+                    Wicked FAQ
+                </ExternalLink>
+                <ExternalLink href="https://github.com/openSUSE/wicked">
+                    Public Wicked Repository
+                </ExternalLink>
+            </EmptyStateSecondaryActions>
+        </EmptyState>
+    );
+};
+
+export default InactiveServicePage;

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -27,7 +27,7 @@ import { PageSection, Spinner, Split, SplitItem } from '@patternfly/react-core';
  *
  * @example
  *
- *  <StatusBar loading>
+ *  <StatusBar showSpinner>
  *      {_("Doing some checks, please be patient...")}
  *  </StatusBar>
  *

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) [2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from 'react';
+import { PageSection, Spinner, Split, SplitItem } from '@patternfly/react-core';
+
+/**
+ * General component to render an status bar
+ *
+ * @example
+ *
+ *  <StatusBar loading>
+ *      {_("Doing some checks, please be patient...")}
+ *  </StatusBar>
+ *
+ * @param {object} props - component props
+ * @param {boolean} [props.showSpinner=false] - when the status bar should display an small spinner
+ * @param {JSX.Element} props.children - content for the status bar
+ */
+const StatusBar = ({
+    showSpinner = false,
+    children
+}) => {
+    return (
+        <PageSection className="content-header-extra">
+            <Split hasGutter id="state" className="content-header-extra--state">
+                { showSpinner && <SplitItem><Spinner size="md" /></SplitItem> }
+                <SplitItem isFilled>{children}</SplitItem>
+            </Split>
+        </PageSection>
+    );
+};
+
+export default StatusBar;

--- a/src/context/network.js
+++ b/src/context/network.js
@@ -218,7 +218,9 @@ function addRoute(dispatch, routes, attrs) {
 }
 
 /**
- * Asks to NetworkClient if service is active or not
+ * Returns if service for interacting with network is active or not
+ *
+ * @return {Promise.<boolean>} Promise that resolves to true if service is active or false if not
  */
 function serviceIsActive() {
     return networkClient().isActive()

--- a/src/context/network.js
+++ b/src/context/network.js
@@ -216,6 +216,19 @@ function addRoute(dispatch, routes, attrs) {
     networkClient().updateRoutes(nextRoutes);
     dispatch({ type: UPDATE_ROUTES, payload: nextRoutes });
 }
+
+/**
+ * Asks to NetworkClient if service is active or not
+ */
+function serviceIsActive() {
+    return networkClient().isActive()
+            .then(result => result)
+            .catch((error) => {
+                console.error(error);
+                return false;
+            });
+}
+
 /**
  * Fetches the interfaces using the NetworkClient
  *
@@ -282,6 +295,7 @@ export {
     fetchInterfaces,
     fetchConnections,
     fetchRoutes,
+    serviceIsActive,
     addRoute,
     updateRoute,
     deleteRoute,

--- a/src/lib/NetworkClient.js
+++ b/src/lib/NetworkClient.js
@@ -39,7 +39,7 @@ class NetworkClient {
      * @return {Promise.<boolean>} Promise that resolves to true if service is active or false if not
      */
     async isActive() {
-        const command = `systemctl --system is-active ${this.adapter.serviceName}`;
+        const command = `systemctl --system is-active ${this.adapter.serviceName()}`;
         const output = await cockpit.spawn(command.split(' '), { superuser: true });
 
         return output.trim() === "active";

--- a/src/lib/NetworkClient.js
+++ b/src/lib/NetworkClient.js
@@ -34,6 +34,15 @@ class NetworkClient {
     }
 
     /**
+     * Whether the network service is active or not
+     *
+     * @return {Promise.<boolean>} Promise that resolves to true if service is active or false if not
+     */
+    async isActive() {
+        return await this.adapter.isActive();
+    }
+
+    /**
      * Returns the list of available connection configurations
      *
      * @returns {Promise<Array|Error>} Resolves to an array of objects in case of success

--- a/src/lib/NetworkClient.js
+++ b/src/lib/NetworkClient.js
@@ -34,12 +34,15 @@ class NetworkClient {
     }
 
     /**
-     * Whether the network service is active or not
+     * Whether the service for interacting with network is active or not
      *
      * @return {Promise.<boolean>} Promise that resolves to true if service is active or false if not
      */
     async isActive() {
-        return await this.adapter.isActive();
+        const command = `systemctl --system is-active ${this.adapter.serviceName}`;
+        const output = await cockpit.spawn(command.split(' '), { superuser: true });
+
+        return output.trim() === "active";
     }
 
     /**

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -35,7 +35,6 @@ import { IfcfgFile, IfrouteFile } from './files';
  */
 class WickedAdapter {
     constructor(client) {
-        this.serviceName = 'wicked';
         this.client = client || new Client();
     }
 
@@ -45,7 +44,7 @@ class WickedAdapter {
      * @return {string} wicked's service name
      */
     serviceName() {
-        return this.serviceName;
+        return 'wicked';
     }
 
     /**

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -39,6 +39,15 @@ class WickedAdapter {
     }
 
     /**
+     * Returns if wicked service is active or not
+     *
+     * @return {Promise.<boolean>} Promise that resolves to true if service is active or false if not
+     */
+    async isActive() {
+        return await this.client.isActive();
+    }
+
+    /**
      * Return a promise that resolves to an array of model Connection objects.
      *
      * @return {Promise.<Array.<Connection>>} Promise that resolves to a list of interfaces

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -26,7 +26,7 @@ import model from '../model';
 import { IfcfgFile, IfrouteFile } from './files';
 
 /**
- * This class is responsible for retrieving and updating Wicked's configuration.
+ * This class is responsible for retrieving and updating wicked's configuration.
  *
  * It relies on WickedClient to get the needed information from Wicked. However,
  * it uses the `sysconfig` files as the mechanism to modify the configuration.
@@ -35,16 +35,17 @@ import { IfcfgFile, IfrouteFile } from './files';
  */
 class WickedAdapter {
     constructor(client) {
+        this.serviceName = 'wicked';
         this.client = client || new Client();
     }
 
     /**
-     * Returns if wicked service is active or not
+     * Return the wicked's service name
      *
-     * @return {Promise.<boolean>} Promise that resolves to true if service is active or false if not
+     * @return {string} wicked's service name
      */
-    async isActive() {
-        return await this.client.isActive();
+    serviceName() {
+        return this.serviceName;
     }
 
     /**

--- a/src/lib/wicked/client.js
+++ b/src/lib/wicked/client.js
@@ -132,21 +132,6 @@ class WickedClient {
     }
 
     /**
-     * Whether the wicked service is active or not
-     *
-     * @return {Promise.<boolean>} Promise that resolves to true if service is active or false if not
-     */
-    async isActive() {
-        // FIXME: not using "--value" option here for backward compatibility with systemd < 230
-        // https://lists.freedesktop.org/archives/systemd-devel/2016-May/036583.html
-        const command = 'systemctl show wicked -p ActiveState';
-        const output = await cockpit.spawn(command.split(' '), { superuser: true });
-        const [_key, value] = output.trim().split('=');
-
-        return value === 'active';
-    }
-
-    /**
      * Returns a promise that resolves to an array of objects representing interfaces
      *
      * @param {object} options - Query options

--- a/src/lib/wicked/client.js
+++ b/src/lib/wicked/client.js
@@ -132,6 +132,21 @@ class WickedClient {
     }
 
     /**
+     * Whether the wicked service is active or not
+     *
+     * @return {Promise.<boolean>} Promise that resolves to true if service is active or false if not
+     */
+    async isActive() {
+        // FIXME: not using "--value" option here for backward compatibility with systemd < 230
+        // https://lists.freedesktop.org/archives/systemd-devel/2016-May/036583.html
+        const command = 'systemctl show wicked -p ActiveState';
+        const output = await cockpit.spawn(command.split(' '), { superuser: true });
+        const [_key, value] = output.trim().split('=');
+
+        return value === 'active';
+    }
+
+    /**
      * Returns a promise that resolves to an array of objects representing interfaces
      *
      * @param {object} options - Query options


### PR DESCRIPTION
Instead of just displaying the `Interfaces` tab with an empty list, now the `cockpit-wicked` package will warn that is not possible to work with wicked because it looks either, not active or nor installed.

| Checking | Service not active |
| - | - |
| ![Screenshot_2020-11-13 Networking - ytm 10 0 0 204](https://user-images.githubusercontent.com/1691872/99075495-7d815880-25b1-11eb-937e-5236a7f0fced.png) | ![Screenshot_2020-11-13 Networking - ytm 10 0 0 204(1)](https://user-images.githubusercontent.com/1691872/99075503-7fe3b280-25b1-11eb-9efb-c79b173f69f6.png) |



