### PR TITLE
Configures an interface w/o ifcfg file in the system

### DIFF
--- a/src/components/InterfaceDetails.js
+++ b/src/components/InterfaceDetails.js
@@ -29,7 +29,7 @@ import WirelessDetails from './WirelessDetails';
 import IPSettingsLink from './IPSettingsLink';
 import DeleteConnection from './DeleteConnection';
 import interfaceTypeEnum from '../lib/model/interfaceType';
-import { Split, SplitItem, Switch } from '@patternfly/react-core';
+import { Split, SplitItem, Switch, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 
 const _ = cockpit.gettext;
 
@@ -105,31 +105,53 @@ const ipV6Details = (connection) => {
     );
 };
 
-const InterfaceDetails = ({ iface, connection, changeConnectionState, removeConnection }) => (
-    <Split hasGutter>
-        <SplitItem isFilled>
-            <dl className="details-list">
-                <dt>{_("Type")}</dt>
-                <dd>{interfaceTypeEnum.label(iface.type)}</dd>
-                { iface.mac && macAddress(iface) }
-                { connection && startMode(connection) }
-                { iface.type === interfaceTypeEnum.BONDING && bondDetails(connection) }
-                { iface.type === interfaceTypeEnum.BRIDGE && bridgeDetails(connection) }
-                { iface.type === interfaceTypeEnum.VLAN && vlanDetails(connection) }
-                { iface.type === interfaceTypeEnum.WIRELESS && wirelessDetails(iface, connection) }
-                { connection && ipV4Details(connection) }
-                { connection && ipV6Details(connection) }
-            </dl>
-        </SplitItem>
-        { connection &&
+const InterfaceDetails = ({ iface, connection, changeConnectionState, removeConnection }) => {
+    const renderActions = () => {
+        if (!connection) return;
+
+        return (
+            <Toolbar>
+                <ToolbarContent>
+                    <ToolbarItem>
+                        <DeleteConnection connection={connection} deleteConnection={removeConnection} />
+                    </ToolbarItem>
+
+                    {
+                        iface &&
+                        <ToolbarItem>
+                            <Switch
+                              id={`status_${iface.name}}`}
+                              isChecked={iface.link}
+                              onChange={() => changeConnectionState(connection, !iface.link)}
+                            />
+                        </ToolbarItem>
+                    }
+                </ToolbarContent>
+            </Toolbar>
+        );
+    };
+
+    return (
+        <Split hasGutter>
+            <SplitItem isFilled>
+                <dl className="details-list">
+                    <dt>{_("Type")}</dt>
+                    <dd>{interfaceTypeEnum.label(iface.type)}</dd>
+                    { iface.mac && macAddress(iface) }
+                    { connection && startMode(connection) }
+                    { iface.type === interfaceTypeEnum.BONDING && bondDetails(connection) }
+                    { iface.type === interfaceTypeEnum.BRIDGE && bridgeDetails(connection) }
+                    { iface.type === interfaceTypeEnum.VLAN && vlanDetails(connection) }
+                    { iface.type === interfaceTypeEnum.WIRELESS && wirelessDetails(iface, connection) }
+                    { connection && ipV4Details(connection) }
+                    { connection && ipV6Details(connection) }
+                </dl>
+            </SplitItem>
             <SplitItem>
-                <DeleteConnection connection={connection} deleteConnection={removeConnection} />
-            </SplitItem>}
-        { iface && connection &&
-            <SplitItem>
-                <Switch id={`status_${iface.name}}`} isChecked={iface.link} onChange={() => changeConnectionState(connection, !iface.link)} />
-            </SplitItem>}
-    </Split>
-);
+                { renderActions() }
+            </SplitItem>
+        </Split>
+    );
+};
 
 export default InterfaceDetails;

--- a/src/components/InterfaceDetails.js
+++ b/src/components/InterfaceDetails.js
@@ -105,7 +105,6 @@ const ipV6Details = (connection) => {
     );
 };
 
-
 const InterfaceDetails = ({ iface, connection, changeConnectionState, removeConnection }) => {
     const renderFullDetails = () => {
         if (connection.exists) {

--- a/src/components/InterfaceDetails.js
+++ b/src/components/InterfaceDetails.js
@@ -105,9 +105,25 @@ const ipV6Details = (connection) => {
     );
 };
 
+
 const InterfaceDetails = ({ iface, connection, changeConnectionState, removeConnection }) => {
+    const renderFullDetails = () => {
+        if (connection.exists) {
+            return (
+                <>
+                    { iface.type === interfaceTypeEnum.BONDING && bondDetails(connection) }
+                    { iface.type === interfaceTypeEnum.BRIDGE && bridgeDetails(connection) }
+                    { iface.type === interfaceTypeEnum.VLAN && vlanDetails(connection) }
+                    { iface.type === interfaceTypeEnum.WIRELESS && wirelessDetails(iface, connection) }
+                    { ipV4Details(connection) }
+                    { ipV6Details(connection) }
+                </>
+            );
+        }
+    };
+
     const renderActions = () => {
-        if (!connection) return;
+        if (!connection.exists) return;
 
         return (
             <Toolbar>
@@ -138,13 +154,8 @@ const InterfaceDetails = ({ iface, connection, changeConnectionState, removeConn
                     <dt>{_("Type")}</dt>
                     <dd>{interfaceTypeEnum.label(iface.type)}</dd>
                     { iface.mac && macAddress(iface) }
-                    { connection && startMode(connection) }
-                    { iface.type === interfaceTypeEnum.BONDING && bondDetails(connection) }
-                    { iface.type === interfaceTypeEnum.BRIDGE && bridgeDetails(connection) }
-                    { iface.type === interfaceTypeEnum.VLAN && vlanDetails(connection) }
-                    { iface.type === interfaceTypeEnum.WIRELESS && wirelessDetails(iface, connection) }
-                    { connection && ipV4Details(connection) }
-                    { connection && ipV6Details(connection) }
+                    {startMode(connection)}
+                    {renderFullDetails()}
                 </dl>
             </SplitItem>
             <SplitItem>

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -78,7 +78,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
         let parentId = 0;
 
         return interfaces.reduce((list, i) => {
-            const conn = connections.find(c => i.name == c.name);
+            const conn = findOrCreateConnection(i.name)
 
             list.push(
                 {

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -66,9 +66,9 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
      * @param {string} name - the interface/connection name
      * @return {module:model/connections~Connection}
      */
-    const findOrCreateConnection = (name) => {
+    const findOrCreateConnection = useCallback((name) => {
         return connections.find(c => c.name === name) || createConnection({ name, exists: false });
-    };
+    }, [connections]);
 
     /**
      * Builds the needed structure for rendering the interfaces and their details in an expandable
@@ -78,7 +78,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
         let parentId = 0;
 
         return interfaces.reduce((list, i) => {
-            const conn = findOrCreateConnection(i.name)
+            const conn = findOrCreateConnection(i.name);
 
             list.push(
                 {
@@ -106,7 +106,7 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
 
             return list;
         }, []);
-    }, [connections, interfaces, openRows, removeConnection, changeState]);
+    }, [interfaces, openRows, removeConnection, changeState, findOrCreateConnection]);
 
     /**
      * Keeps the openRows internal state up to date using the information provided by the

--- a/src/components/InterfacesList.js
+++ b/src/components/InterfacesList.js
@@ -26,6 +26,7 @@ import { Table, TableHeader, TableBody, TableVariant, expandable } from '@patter
 import InterfaceDetails from "./InterfaceDetails";
 import interfaceType from '../lib/model/interfaceType';
 import { useNetworkDispatch, deleteConnection, changeConnectionState } from '../context/network';
+import { createConnection } from '../lib/model/connections';
 
 const _ = cockpit.gettext;
 
@@ -53,6 +54,20 @@ const InterfacesList = ({ interfaces = [], connections = [] }) => {
         if (iface.addresses.length === 0) return;
 
         return iface.addresses.map(i => i.local).join(', ');
+    };
+
+    /**
+     * Returns the connection for given interface name or a fake one if it does not exist yet
+     *
+     * When a connection does not exist yet, the user should be able to create one by configuring
+     * the interface. To achieve that, a "default" connection object is needed, in order to build
+     * the needed UI.
+     *
+     * @param {string} name - the interface/connection name
+     * @return {module:model/connections~Connection}
+     */
+    const findOrCreateConnection = (name) => {
+        return connections.find(c => c.name === name) || createConnection({ name, exists: false });
     };
 
     /**

--- a/src/components/StartMode.js
+++ b/src/components/StartMode.js
@@ -22,7 +22,7 @@
 import React, { useState } from 'react';
 import cockpit from 'cockpit';
 import { FormSelect, FormSelectOption, ModalVariant } from '@patternfly/react-core';
-import { useNetworkDispatch, updateConnection } from '../context/network';
+import { useNetworkDispatch, addConnection, updateConnection } from '../context/network';
 import startModeEnum from '../lib/model/startMode';
 import ModalForm from './ModalForm';
 
@@ -42,11 +42,24 @@ const StartMode = ({ connection }) => {
 
     const handleSubmit = () => {
         // TODO: notify that something went wrong.
-        updateConnection(dispatch, connection, { startMode });
+        if (connection.exists) {
+            updateConnection(dispatch, connection, { startMode });
+        } else {
+            addConnection(dispatch, { ...connection, startMode });
+        }
+
         closeForm();
     };
 
+    const renderLink = () => {
+        const label = connection.exists ? startModeEnum.label(connection.startMode) : _("Not configured");
+
+        return <a href="#" onClick={openForm}>{label}</a>;
+    };
+
     const renderModalForm = () => {
+        if (!isOpen) return;
+
         return (
             <ModalForm
               caption={connection.name}
@@ -67,8 +80,8 @@ const StartMode = ({ connection }) => {
 
     return (
         <>
-            <a href="#" onClick={openForm}>{startModeEnum.label(connection.startMode)}</a>
-            { isOpen && renderModalForm() }
+            { renderLink() }
+            { renderModalForm() }
         </>
     );
 };

--- a/src/components/StartMode.js
+++ b/src/components/StartMode.js
@@ -22,7 +22,7 @@
 import React, { useState } from 'react';
 import cockpit from 'cockpit';
 import { FormSelect, FormSelectOption, ModalVariant } from '@patternfly/react-core';
-import { useNetworkDispatch, addConnection, updateConnection } from '../context/network';
+import { useNetworkDispatch, configureInterface, updateConnection } from '../context/network';
 import startModeEnum from '../lib/model/startMode';
 import ModalForm from './ModalForm';
 
@@ -45,7 +45,7 @@ const StartMode = ({ connection }) => {
         if (connection.exists) {
             updateConnection(dispatch, connection, { startMode });
         } else {
-            addConnection(dispatch, { ...connection, startMode });
+            configureInterface(dispatch, { ...connection, startMode });
         }
 
         closeForm();

--- a/src/components/StartMode.js
+++ b/src/components/StartMode.js
@@ -22,7 +22,7 @@
 import React, { useState } from 'react';
 import cockpit from 'cockpit';
 import { FormSelect, FormSelectOption, ModalVariant } from '@patternfly/react-core';
-import { useNetworkDispatch, configureInterface, updateConnection } from '../context/network';
+import { useNetworkDispatch, addConnection, updateConnection } from '../context/network';
 import startModeEnum from '../lib/model/startMode';
 import ModalForm from './ModalForm';
 
@@ -45,7 +45,7 @@ const StartMode = ({ connection }) => {
         if (connection.exists) {
             updateConnection(dispatch, connection, { startMode });
         } else {
-            configureInterface(dispatch, { ...connection, startMode });
+            addConnection(dispatch, { ...connection, startMode });
         }
 
         closeForm();

--- a/src/context/network.js
+++ b/src/context/network.js
@@ -31,7 +31,6 @@ const NetworkDispatchContext = React.createContext();
 // TODO: document and test this context.
 
 const SET_INTERFACES = 'set_interfaces';
-const CONFIGURE_INTERFACE = 'configure_interface';
 const SET_CONNECTIONS = 'set_connections';
 const SET_ROUTES = 'set_routes';
 const UPDATE_ROUTES = 'update_routes';
@@ -42,7 +41,6 @@ const UPDATE_INTERFACE = 'update_interface';
 
 const actionTypes = {
     SET_INTERFACES,
-    CONFIGURE_INTERFACE,
     SET_CONNECTIONS,
     SET_ROUTES,
     UPDATE_ROUTES,
@@ -87,25 +85,15 @@ function networkReducer(state, action) {
         const { interfaces, connections } = state;
         const conn = action.payload;
 
-        const iface = createInterface({ name: conn.name, type: conn.type });
+        // Configuring an existing iface?
+        let iface = Object.values(interfaces).find((i) => i.name === conn.name);
+
+        // or just adding a new one?
+        iface ||= createInterface({ name: conn.name, type: conn.type });
 
         return {
             ...state,
             interfaces: { ...interfaces, [iface.id]: iface },
-            connections: { ...connections, [conn.id]: conn }
-        };
-    }
-
-    case CONFIGURE_INTERFACE: {
-        const { interfaces, connections } = state;
-        const conn = action.payload;
-
-        const iface = Object.values(interfaces).find((i) => i.name === conn.name);
-
-        if (!iface) return;
-
-        return {
-            ...state,
             connections: { ...connections, [conn.id]: conn }
         };
     }
@@ -194,7 +182,9 @@ const networkClient = () => {
 /**
  * Creates a connection using the NetworkClient
  *
- * It dispatches the ADD_CONNECTION action.
+ * It dispatches the ADD_CONNECTION action. Additionally, if it created the connection from a
+ * default one (`exists: false`) the UPDATE_CONNECTION action will be dispatched too when the
+ * NetworkClient finish its work.
  *
  * @todo Notify when something went wrong.
  *
@@ -205,27 +195,12 @@ const networkClient = () => {
 async function addConnection(dispatch, attrs) {
     const addedConn = createConnection(attrs);
     dispatch({ type: ADD_CONNECTION, payload: addedConn });
-    return await networkClient().addConnection(addedConn);
-}
-
-/**
- * Configures an interface by creating a connection for it using the NetworkClient
- *
- * It dispatches the CONFIGURE_INTERFACAE action once the NetworkClient finish its work.
- *
- * @todo Notify when something went wrong.
- *
- * @param {function} dispatch - Dispatch function
- * @param {Object} attrs - connection attributes
- * @return {Promise}
- */
-async function configureInterface(dispatch, attrs) {
-    const connection = createConnection({ ...attrs, creating: true });
     return await networkClient()
-            .addConnection(connection)
+            .addConnection(addedConn)
             .then((conn) => {
-                dispatch({ type: CONFIGURE_INTERFACE, payload: { ...conn, exists: true } });
-                return conn;
+                if (!attrs.exists) {
+                    dispatch({ type: UPDATE_CONNECTION, payload: { ...addedConn, exists: true } });
+                }
             });
 }
 
@@ -368,7 +343,6 @@ export {
     deleteConnection,
     updateConnection,
     changeConnectionState,
-    configureInterface,
     fetchInterfaces,
     fetchConnections,
     fetchRoutes,

--- a/src/context/network.js
+++ b/src/context/network.js
@@ -192,15 +192,16 @@ const networkClient = () => {
  * @param {Object} attrs - Attributes for the new connection
  * @return {Promise}
  */
-async function addConnection(dispatch, attrs) {
+function addConnection(dispatch, attrs) {
     const addedConn = createConnection(attrs);
     dispatch({ type: ADD_CONNECTION, payload: addedConn });
-    return await networkClient()
+    return networkClient()
             .addConnection(addedConn)
-            .then((conn) => {
+            .then(conn => {
                 if (!attrs.exists) {
                     dispatch({ type: UPDATE_CONNECTION, payload: { ...addedConn, exists: true } });
                 }
+                networkClient().reloadConnection(addedConn.name);
             });
 }
 
@@ -216,11 +217,13 @@ async function addConnection(dispatch, attrs) {
  * @param {Object|Connection} changes - Changes to apply to the connection
  * @return {Promise}
  */
-async function updateConnection(dispatch, connection, changes) {
+function updateConnection(dispatch, connection, changes) {
     const updatedConn = mergeConnection(connection, changes);
     dispatch({ type: UPDATE_CONNECTION, payload: updatedConn });
     // FIXME: handle errors
-    return await networkClient().updateConnection(updatedConn);
+    return networkClient()
+            .updateConnection(updatedConn)
+            .then(() => networkClient().reloadConnection(updatedConn.name));
 }
 
 async function deleteConnection(dispatch, connection) {

--- a/src/context/network.test.js
+++ b/src/context/network.test.js
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-import { addConnection, updateConnection, configureInterface, actionTypes, resetClient } from './network';
+import { addConnection, updateConnection, actionTypes, resetClient } from './network';
 import model from '../lib/model';
 import interfaceType from '../lib/model/interfaceType';
 import NetworkClient from '../lib/NetworkClient';
@@ -42,42 +42,6 @@ describe('#addConnection', () => {
         return addConnection(dispatchFn, { name: 'eth0', type: interfaceType.BRIDGE })
                 .then(result => {
                     expect(result).toEqual(expect.objectContaining({ name: 'eth0' }));
-                });
-    });
-});
-
-describe('#configureInterface', () => {
-    beforeAll(() => {
-        NetworkClient.mockImplementation(() => {
-            return {
-                addConnection: (conn) => Promise.resolve(conn)
-            };
-        });
-    });
-
-    it('asks the network client to add a connection', () => {
-        const dispatchFn = jest.fn();
-
-        expect.assertions(1);
-        return configureInterface(dispatchFn, { name: 'eth0', type: interfaceType.ETHERNET })
-                .then(result => {
-                    expect(result).toEqual(expect.objectContaining({ name: 'eth0' }));
-                });
-    });
-
-    it('dispatches a CONFIGURE_INTERFACE action with created action marked as present', () => {
-        const dispatchFn = jest.fn();
-        const conn = model.createConnection({ name: 'eth0' });
-        const expectedPayload = { name: conn.name, type: conn.type, exists: true };
-
-        return configureInterface(dispatchFn, conn)
-                .then(result => {
-                    expect(dispatchFn).toHaveBeenCalledWith(
-                        expect.objectContaining({
-                            type: actionTypes.CONFIGURE_INTERFACE,
-                            payload: expect.objectContaining(expectedPayload)
-                        })
-                    );
                 });
     });
 });

--- a/src/lib/NetworkClient.js
+++ b/src/lib/NetworkClient.js
@@ -81,6 +81,16 @@ class NetworkClient {
         return this.adapter.removeConnection(connection);
     }
 
+    /**
+     * Reloads a connection
+     *
+     * @param {String} name - Connection's name
+     * @returns {Promise}
+     */
+    reloadConnection(name) {
+        return this.adapter.reloadConnection(name);
+    }
+
     setUpConnection(connection) {
         return this.adapter.setUpConnection(connection);
     }

--- a/src/lib/model/connections.js
+++ b/src/lib/model/connections.js
@@ -27,13 +27,20 @@ import bondingModeEnum from '../model/bondingMode';
 let connectionIndex = 0;
 
 /**
+ * @typedef {Object} IPConf
+ * @property {Array<Object>} addresses - Address configurations
+ * @property {string} bootProto - Boot protocol (@see model/bootProtocol)
+ */
+
+/**
  * @typedef {Object} Connection
  * @property {string} name - Connection name
  * @property {string} description - Connection description
  * @property {string} type - Connection type (@see model/interfaceType)
- * @property {string} bootProto - Boot protocol (@see model/bootProtocol)
  * @property {string} interfaceName - Associated interface name
- * @property {Array<Object>} addresses - Address configurations
+ * @property {string} startMode - the connection start mode (@see model/startMode)
+ * @property {IPconf} ipv4 - IPv4 configuration
+ * @property {IPconf} ipv6 - IPv6 configuration
  * @property {boolean} exists - Whether the connection was loaded from the system or not
  * @property {boolean} virtual - Whether it corresponds to a virtual interface or not
  */
@@ -43,13 +50,14 @@ let connectionIndex = 0;
  *
  * Returns an object representing a connection
  *
- * @param {object} args - Connection properties
- * @param {string} args.name - Name
- * @param {string} args.description - Description
- * @param {string} args.type - Connection type ('eth', 'br', etc.)
- * @param {string} args.bootProto - Boot protocol ('dhcp', 'static', etc.)
- * @param {string} args.interfaceName - Name of the interface associated to this connection
- * @param {string} args.addresses - Address configurations
+ * @param {object}  args - Connection properties
+ * @param {string}  args.name - Name
+ * @param {string}  args.description - Description
+ * @param {string}  args.type - Connection type (@see model/interfaceType)
+ * @param {string}  args.interfaceName - Name of the interface associated to this connection
+ * @param {string}  args.startMode - the connection start mode (@see model/startMode)
+ * @param {IPConf}  args.ipv4 - Configuration for IPv4
+ * @param {IPConf}  args.ipv6 - Configuration for IPv6
  * @param {boolean} [args.exists=true] - Whether the connection was loaded from the system or not
  *
  * @return {Connection} Connection object

--- a/src/lib/model/connections.js
+++ b/src/lib/model/connections.js
@@ -34,6 +34,7 @@ let connectionIndex = 0;
  * @property {string} bootProto - Boot protocol (@see model/bootProtocol)
  * @property {string} interfaceName - Associated interface name
  * @property {Array<Object>} addresses - Address configurations
+ * @property {boolean} exists - Whether the connection was loaded from the system or not
  * @property {boolean} virtual - Whether it corresponds to a virtual interface or not
  */
 
@@ -49,6 +50,8 @@ let connectionIndex = 0;
  * @param {string} args.bootProto - Boot protocol ('dhcp', 'static', etc.)
  * @param {string} args.interfaceName - Name of the interface associated to this connection
  * @param {string} args.addresses - Address configurations
+ * @param {boolean} [args.exists=true] - Whether the connection was loaded from the system or not
+ *
  * @return {Connection} Connection object
  */
 export const createConnection = ({
@@ -59,6 +62,7 @@ export const createConnection = ({
     startMode = startModeEnum.AUTO,
     ipv4 = { addresses: [], bootProto: bootProtocol.DHCP },
     ipv6 = { addresses: [], bootProto: bootProtocol.DHCP },
+    exists = true,
     ...rest
 }) => {
     return {
@@ -70,6 +74,7 @@ export const createConnection = ({
         startMode,
         ipv4,
         ipv6,
+        exists,
         virtual: interfaceType.isVirtual(type),
         ...propsByType(type, rest)
     };

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -53,7 +53,7 @@ class WickedAdapter {
      * @return {Promise.<Array.<Connection>>} Promise that resolves to a list of interfaces
      */
     async connections() {
-        const conns = await this.client.getConfigurations();
+        const conns = await this.client.getConfigurations() || [];
         return conns.map(createConnection).filter(c => c.name !== 'lo');
     }
 

--- a/src/lib/wicked/adapter.js
+++ b/src/lib/wicked/adapter.js
@@ -122,7 +122,6 @@ class WickedAdapter {
     addConnection(connection) {
         return new Promise((resolve, reject) => {
             this.updateConnectionConfig(connection)
-                    .then(() => this.reloadConnection(connection.name))
                     .then(() => resolve(connection))
                     .catch(reject);
         });
@@ -136,9 +135,7 @@ class WickedAdapter {
      */
     removeConnection(connection) {
         return new Promise((resolve, reject) => {
-            const name = connection.name;
             this.deleteConnectionConfig(connection)
-                    .then(() => this.reloadConnection(name))
                     .catch(reject);
         });
     }
@@ -152,7 +149,6 @@ class WickedAdapter {
     updateConnection(connection) {
         return new Promise((resolve, reject) => {
             this.updateConnectionConfig(connection)
-                    .then(() => this.reloadConnection(connection.name))
                     .then(() => resolve(connection))
                     .catch(reject);
         });


### PR DESCRIPTION
This PR mainly allows configuring an interface without a configuration file in the system. 

![configure-interface](https://user-images.githubusercontent.com/15836/99385988-acf1d700-28c9-11eb-8df8-bea1edb6302f.gif)

### Implementation details

After some discussions, we agreed on having a _fake_ object connection for such cases, which 

* Fallback to default values
* Has a flag to distinguish it from a _real_ configuration representation

### (PENDING) Visual improvements

Although I implemented them, I exclude them for now, but IMHO it would be nice

* To have _something_ in the list (e.g., an icon) indicating that the interface is not configured.
  
  ![Screen Shot 2020-11-16 at 18 23 19](https://user-images.githubusercontent.com/1691872/99308076-4c25b880-284f-11eb-804c-862a3a4613f9.png)

* ~~To give feedback after setting the start mode (aka, _creating the missing configuration file_).~~ (done)